### PR TITLE
Add setup only flag

### DIFF
--- a/cmake/Sources.cmake
+++ b/cmake/Sources.cmake
@@ -2,6 +2,7 @@ include(${PROJECT_SOURCE_DIR}/cmake/Utils.cmake)
 
 set(JAMS_SOURCES_CXX
         containers/cell.cc
+        core/args.cc
         core/hamiltonian.cc
         core/interactions.cc
         core/jams++.cc

--- a/src/jams/core/args.cc
+++ b/src/jams/core/args.cc
@@ -1,0 +1,45 @@
+//
+// Created by Joseph Barker on 2019-11-12.
+//
+#include <string>
+#include "jams/core/args.h"
+#include "jams/helpers/utils.h"
+
+namespace jams {
+    bool arg_is_flag(const std::string& arg) {
+      return arg.rfind("--", 0) == 0;
+    }
+
+    void process_flag(const std::string& flag, ProgramArgs& program_args) {
+      if (flag == "--setup-only") {
+        program_args.setup_only = true;
+        return;
+      }
+
+      throw std::runtime_error("Unknown flag \'" + flag + "\'");
+    }
+
+    ProgramArgs parse_args(int argc, char **argv) {
+      if (argc == 1) throw std::runtime_error("No config file specified");
+
+      ProgramArgs program_args;
+      for (auto n = 1; n < argc; ++n) {
+        std::string arg(argv[n]);
+        trim(arg);
+
+        if (arg_is_flag(arg)) {
+          process_flag(arg, program_args);
+        } else {
+          if (program_args.config_file_path.empty()) {
+            program_args.config_file_path = arg;
+          } else if (program_args.config_file_patch.empty()) {
+            program_args.config_file_patch  = arg;
+          } else {
+            throw std::runtime_error("too many string arguments on command line");
+          }
+        }
+      }
+
+      return program_args;
+    }
+}

--- a/src/jams/core/args.h
+++ b/src/jams/core/args.h
@@ -1,0 +1,21 @@
+//
+// Created by Joseph Barker on 2019-11-12.
+//
+
+#ifndef JAMS_ARGS_H
+#define JAMS_ARGS_H
+
+#include <string>
+
+namespace jams {
+
+    struct ProgramArgs {
+        bool        setup_only        = false;
+        std::string config_file_path  = "";
+        std::string config_file_patch = "";
+    };
+
+    ProgramArgs parse_args(int argc, char **argv);
+}
+
+#endif //JAMS_ARGS_H

--- a/src/jams/core/jams++.cc
+++ b/src/jams/core/jams++.cc
@@ -10,6 +10,7 @@
   #include <omp.h>
 #endif
 
+#include "jams/core/args.h"
 #include "jams/core/globals.h"
 #include "jams/core/hamiltonian.h"
 #include "jams/core/jams++.h"
@@ -44,30 +45,22 @@ namespace jams {
       delete config;
     }
 
-    void parse_args(int argc, char **argv, jams::Simulation &sim) {
-      if (argc == 1) jams_die("No config file specified");
-
-      sim.config_file_name    = trim(string(argv[1]));
-      sim.config_patch_string = (argc == 3 ? string(argv[2]) : "");
-      sim.name                = trim(file_basename(sim.config_file_name));
-    }
-
     void parse_config(jams::Simulation &sim) {
       try {
         config->readFile(sim.config_file_name.c_str());
       }
-      catch(const libconfig::FileIOException &fioex) {
+      catch (const libconfig::FileIOException &fioex) {
         jams_die("I/O error while reading '%s'", sim.config_file_name.c_str());
       }
-      catch(const libconfig::ParseException &pex) {
+      catch (const libconfig::ParseException &pex) {
         jams_die("Error parsing %s:%i: %s", pex.getFile(),
                  pex.getLine(), pex.getError());
       }
 
-      jams_patch_config(sim.config_patch_string);
+      patch_config(sim.config_patch_string);
     }
 
-    std::string section(const std::string& name) {
+    std::string section(const std::string &name) {
       std::string line = "\n--------------------------------------------------------------------------------\n";
       return line.replace(1, name.size() + 1, name + " ");
     }
@@ -114,209 +107,215 @@ namespace jams {
       #endif
       return ss.str();
     }
-}
 
-void jams_initialize(int argc, char **argv) {
-  jams::desync_io();
-  cout << jams::header();
+    void initialize_simulation(const jams::ProgramArgs &program_args) {
+      jams::desync_io();
+      cout << jams::header();
 
-  jams::Simulation simulation;
-  jams::new_global_classes();
-  jams::parse_args(argc, argv, simulation);
-  seedname = simulation.name;
-  cout << "config  " << simulation.config_file_name << "\n";   // TODO: tee cout also to a log file
+      jams::Simulation simulation;
 
-  jams::parse_config(simulation);
+      simulation.config_file_name = program_args.config_file_path;
+      simulation.config_patch_string = program_args.config_file_patch;
+      simulation.name = trim(file_basename(simulation.config_file_name));
 
-  simulation.random_state = jams::random_generator_internal_state();
+      seedname = simulation.name;
+      cout << "config  " << simulation.config_file_name << "\n";   // TODO: tee cout also to a log file
 
-  try {
-    ::config->setAutoConvert(true);
-    if (::config->exists("sim")) {
-      simulation.verbose = jams::config_optional<bool>(config->lookup("sim"), "verbose", false);
+      jams::new_global_classes();
 
-      if (config->exists("sim.seed")) {
-        simulation.random_seed = jams::config_required<unsigned long>(config->lookup("sim"), "seed");
-        jams::random_generator().seed(simulation.random_seed);
-        cout << "seed    "   << simulation.random_seed << "\n";
-      }
+      jams::parse_config(simulation);
 
-      if (config->exists("sim.rng_state")) {
-        auto state = jams::config_required<string>(config->lookup("sim"), "rng_state");
-        istringstream(state) >> simulation.random_state;
-      }
-    }
+      simulation.random_state = jams::random_generator_internal_state();
 
-    cout << "verbose "   << simulation.verbose << "\n";
-    cout << "rng state " << simulation.random_state << "\n";
+      try {
+        ::config->setAutoConvert(true);
+        if (::config->exists("sim")) {
+          simulation.verbose = jams::config_optional<bool>(config->lookup("sim"), "verbose", false);
 
-    cout << jams::section("init lattice") << std::endl;
+          if (config->exists("sim.seed")) {
+            simulation.random_seed = jams::config_required<unsigned long>(config->lookup("sim"), "seed");
+            jams::random_generator().seed(simulation.random_seed);
+            cout << "seed    " << simulation.random_seed << "\n";
+          }
 
-    lattice->init_from_config(*::config);
-
-    cout << jams::section("init solver") << std::endl;
-
-    solver = Solver::create(config->lookup("solver"));
-    solver->initialize(config->lookup("solver"));
-    solver->register_physics_module(Physics::create(config->lookup("physics")));     // todo: fix this memory leak
-
-    cout << jams::section("init hamiltonians") << std::endl;
-
-    if (!::config->exists("hamiltonians")) {
-      jams_die("No hamiltonians in config");
-    } else {
-      const libconfig::Setting &hamiltonian_settings = ::config->lookup("hamiltonians");
-      for (auto i = 0; i < hamiltonian_settings.getLength(); ++i) {
-        solver->register_hamiltonian(Hamiltonian::create(hamiltonian_settings[i], globals::num_spins, solver->is_cuda_solver()));
-      }
-    }
-
-    cout << jams::section("init monitors") << std::endl;
-
-    if (!::config->exists("monitors")) {
-      jams_warning("No monitors in config");
-    } else {
-      const libconfig::Setting &monitor_settings = ::config->lookup("monitors");
-      for (auto i = 0; i < monitor_settings.getLength(); ++i) {
-        solver->register_monitor(Monitor::create(monitor_settings[i]));
-      }
-    }
-
-    if(::config->exists("initializer")) {
-      jams_global_initializer(::config->lookup("initializer"));
-    }
-  }
-  catch(const libconfig::SettingTypeException &stex) {
-    jams_die("Config setting type error '%s'", stex.getPath());
-  }
-  catch(const libconfig::SettingNotFoundException &nfex) {
-    jams_die("Required config setting not found '%s'", nfex.getPath());
-  }
-  catch(const jams::runtime_error &gex) {
-    jams_die("%s", gex.what());
-  }
-  catch (std::exception& e) {
-    jams_die("%s", e.what());
-  }
-  catch(...) {
-    jams_die("Caught an unknown exception");
-  }
-}
-
-void jams_run() {
-  try {
-    cout << jams::section("running solver") << std::endl;
-    cout << "start   " << get_date_string(std::chrono::system_clock::now()) << "\n" << std::endl;
-    {
-      ProgressBar progress;
-      Timer<> timer;
-      while (::solver->is_running()) {
-        if (::solver->is_converged()) {
-          break;
+          if (config->exists("sim.rng_state")) {
+            auto state = jams::config_required<string>(config->lookup("sim"), "rng_state");
+            istringstream(state) >> simulation.random_state;
+          }
         }
 
-        ::solver->update_physics_module();
-        ::solver->notify_monitors();
-        ::solver->run();
+        cout << "verbose " << simulation.verbose << "\n";
+        cout << "rng state " << simulation.random_state << "\n";
 
-        progress.set(double(::solver->iteration()) / double(::solver->max_steps()));
-        if (::solver->iteration() % 1000 == 0) {
-          cout << progress;
+        cout << jams::section("init lattice") << std::endl;
+
+        lattice->init_from_config(*::config);
+
+        cout << jams::section("init solver") << std::endl;
+
+        solver = Solver::create(config->lookup("solver"));
+        solver->initialize(config->lookup("solver"));
+        solver->register_physics_module(Physics::create(config->lookup("physics")));     // todo: fix this memory leak
+
+        cout << jams::section("init hamiltonians") << std::endl;
+
+        if (!::config->exists("hamiltonians")) {
+          jams_die("No hamiltonians in config");
+        } else {
+          const libconfig::Setting &hamiltonian_settings = ::config->lookup("hamiltonians");
+          for (auto i = 0; i < hamiltonian_settings.getLength(); ++i) {
+            solver->register_hamiltonian(
+                Hamiltonian::create(hamiltonian_settings[i], globals::num_spins, solver->is_cuda_solver()));
+          }
+        }
+
+        cout << jams::section("init monitors") << std::endl;
+
+        if (!::config->exists("monitors")) {
+          jams_warning("No monitors in config");
+        } else {
+          const libconfig::Setting &monitor_settings = ::config->lookup("monitors");
+          for (auto i = 0; i < monitor_settings.getLength(); ++i) {
+            solver->register_monitor(Monitor::create(monitor_settings[i]));
+          }
+        }
+
+        if (::config->exists("initializer")) {
+          global_initializer(::config->lookup("initializer"));
         }
       }
-      cout << "\n\n";
-      cout << "runtime " << timer.elapsed_time() << " seconds" << std::endl;
-
-      cout << "finish  " << get_date_string(std::chrono::system_clock::now()) << "\n\n";
-    }
-
-    {
-      cout << jams::section("running post process") << std::endl;
-      cout << "start   " << get_date_string(std::chrono::system_clock::now()) << "\n" << std::endl;
-
-      Timer<> timer;
-
-      for (auto m : solver->monitors()) {
-        m->post_process();
+      catch (const libconfig::SettingTypeException &stex) {
+        jams_die("Config setting type error '%s'", stex.getPath());
       }
-      cout << "runtime " << timer.elapsed_time() << " seconds" << std::endl;
-      cout << "finish  " << get_date_string(std::chrono::system_clock::now()) << "\n\n";
+      catch (const libconfig::SettingNotFoundException &nfex) {
+        jams_die("Required config setting not found '%s'", nfex.getPath());
+      }
+      catch (const jams::runtime_error &gex) {
+        jams_die("%s", gex.what());
+      }
+      catch (std::exception &e) {
+        jams_die("%s", e.what());
+      }
+      catch (...) {
+        jams_die("Caught an unknown exception");
+      }
     }
 
-  }
-  catch(const jams::runtime_error &gex) {
-    jams_die("%s", gex.what());
-  }
-  catch (std::exception& e) {
-    jams_die("%s", e.what());
-  }
-  catch(...) {
-    jams_die("Caught an unknown exception");
-  }
-}
+    void run_simulation() {
+      try {
+        cout << jams::section("running solver") << std::endl;
+        cout << "start   " << get_date_string(std::chrono::system_clock::now()) << "\n" << std::endl;
+        {
+          ProgressBar progress;
+          Timer<> timer;
+          while (::solver->is_running()) {
+            if (::solver->is_converged()) {
+              break;
+            }
 
-void jams_finish() {
-  jams::delete_global_classes();
-}
+            ::solver->update_physics_module();
+            ::solver->notify_monitors();
+            ::solver->run();
 
-void jams_global_initializer(const libconfig::Setting &settings) {
-  if (settings.exists("spins")) {
-    std::string file_name = settings["spins"];
-    cout << "reading spin data from file " << file_name << "\n";
-    load_array_from_file(file_name, "/spins", globals::s);
-  }
+            progress.set(double(::solver->iteration()) / double(::solver->max_steps()));
+            if (::solver->iteration() % 1000 == 0) {
+              cout << progress;
+            }
+          }
+          cout << "\n\n";
+          cout << "runtime " << timer.elapsed_time() << " seconds" << std::endl;
 
-  if (settings.exists("alpha")) {
-    std::string file_name = settings["alpha"];
-    cout << "reading alpha data from file " << file_name << "\n";
-    load_array_from_file(file_name, "/alpha", globals::alpha);
-  }
+          cout << "finish  " << get_date_string(std::chrono::system_clock::now()) << "\n\n";
+        }
 
-  if (settings.exists("mus")) {
-    std::string file_name = settings["mus"];
-    cout << "reading mus data from file " << file_name << "\n";
-    load_array_from_file(file_name, "/mus", globals::mus);
-  }
+        {
+          cout << jams::section("running post process") << std::endl;
+          cout << "start   " << get_date_string(std::chrono::system_clock::now()) << "\n" << std::endl;
 
-  if (settings.exists("gyro")) {
-    std::string file_name = settings["gyro"];
-    cout << "reading gyro data from file " << file_name << "\n";
-    load_array_from_file(file_name, "/gyro", globals::gyro);
-  }
-}
+          Timer<> timer;
 
-void jams_patch_config(const std::string &patch_string) {
-  libconfig::Config cfg_patch;
+          for (auto m : solver->monitors()) {
+            m->post_process();
+          }
+          cout << "runtime " << timer.elapsed_time() << " seconds" << std::endl;
+          cout << "finish  " << get_date_string(std::chrono::system_clock::now()) << "\n\n";
+        }
 
-  if (patch_string.empty()) return;
+      }
+      catch (const jams::runtime_error &gex) {
+        jams_die("%s", gex.what());
+      }
+      catch (std::exception &e) {
+        jams_die("%s", e.what());
+      }
+      catch (...) {
+        jams_die("Caught an unknown exception");
+      }
+    }
 
-  try {
-    cfg_patch.readFile(patch_string.c_str());
-    cout << "patching form file " << patch_string << "\n";
-  }
-  catch(libconfig::FileIOException &fex) {
-    cfg_patch.readString(patch_string);
-    cout << "patching from string " << patch_string << "\n";
-  }
-  catch(const libconfig::ParseException &pex) {
-    jams_die("Error parsing %s:%i: %s", pex.getFile(),
-             pex.getLine(), pex.getError());
-  }
+    void cleanup_simulation() {
+      jams::delete_global_classes();
+    }
 
-  config_patch(::config->getRoot(), cfg_patch.getRoot());
+    void global_initializer(const libconfig::Setting &settings) {
+      if (settings.exists("spins")) {
+        std::string file_name = settings["spins"];
+        cout << "reading spin data from file " << file_name << "\n";
+        load_array_from_file(file_name, "/spins", globals::s);
+      }
 
-  bool do_write_patched_config = true;
+      if (settings.exists("alpha")) {
+        std::string file_name = settings["alpha"];
+        cout << "reading alpha data from file " << file_name << "\n";
+        load_array_from_file(file_name, "/alpha", globals::alpha);
+      }
 
-  config->lookupValue("sim.write_patched_config", do_write_patched_config);
+      if (settings.exists("mus")) {
+        std::string file_name = settings["mus"];
+        cout << "reading mus data from file " << file_name << "\n";
+        load_array_from_file(file_name, "/mus", globals::mus);
+      }
 
-  if (do_write_patched_config) {
-    std::string patched_config_filename = seedname + "_patched.cfg";
+      if (settings.exists("gyro")) {
+        std::string file_name = settings["gyro"];
+        cout << "reading gyro data from file " << file_name << "\n";
+        load_array_from_file(file_name, "/gyro", globals::gyro);
+      }
+    }
+
+    void patch_config(const std::string &patch_string) {
+      libconfig::Config cfg_patch;
+
+      if (patch_string.empty()) return;
+
+      try {
+        cfg_patch.readFile(patch_string.c_str());
+        cout << "patching form file " << patch_string << "\n";
+      }
+      catch (libconfig::FileIOException &fex) {
+        cfg_patch.readString(patch_string);
+        cout << "patching from string " << patch_string << "\n";
+      }
+      catch (const libconfig::ParseException &pex) {
+        jams_die("Error parsing %s:%i: %s", pex.getFile(),
+                 pex.getLine(), pex.getError());
+      }
+
+      config_patch(::config->getRoot(), cfg_patch.getRoot());
+
+      bool do_write_patched_config = true;
+
+      config->lookupValue("sim.write_patched_config", do_write_patched_config);
+
+      if (do_write_patched_config) {
+        std::string patched_config_filename = seedname + "_patched.cfg";
 
 #if (((LIBCONFIG_VER_MAJOR == 1) && (LIBCONFIG_VER_MINOR >= 6)) \
-     || (LIBCONFIG_VER_MAJOR > 1))
-    ::config->setFloatPrecision(8);
+ || (LIBCONFIG_VER_MAJOR > 1))
+        ::config->setFloatPrecision(8);
 #endif
 
-    ::config->writeFile(patched_config_filename.c_str());
-  }
+        ::config->writeFile(patched_config_filename.c_str());
+      }
+    }
 }

--- a/src/jams/core/jams++.h
+++ b/src/jams/core/jams++.h
@@ -7,6 +7,7 @@
 #include <libconfig.h++>
 #include <random>
 
+#include "jams/core/args.h"
 #include "jams/helpers/defaults.h"
 
 namespace jams {
@@ -20,12 +21,14 @@ namespace jams {
         std::string   random_state;
         unsigned long random_seed;
     };
+
+    void initialize_simulation(const jams::ProgramArgs& program_args);
+    void patch_config(const std::string &patch_string);
+    void run_simulation();
+    void cleanup_simulation();
+    void global_initializer(const libconfig::Setting &settings);
 }
 
-void jams_initialize(int argc, char **argv);
-void jams_patch_config(const std::string &patch_string);
-void jams_run();
-void jams_finish();
-void jams_global_initializer(const libconfig::Setting &settings);
+
 
 #endif

--- a/src/jams/helpers/error.cc
+++ b/src/jams/helpers/error.cc
@@ -22,7 +22,7 @@ void jams_die(const char *message, ...) {
   cerr << "ERROR: " << buffer << "\n\n";
   cerr << "********************************************************************************\n\n";
 
-  jams_finish();
+  jams::cleanup_simulation();
   exit(EXIT_FAILURE);
 }
 

--- a/src/jams/main.cc
+++ b/src/jams/main.cc
@@ -1,10 +1,17 @@
 #include <cstdlib>
 
 #include "jams/core/jams++.h"
+#include "jams/core/args.h"
 
 int main(int argc, char **argv) {
-  jams_initialize(argc, argv);
-  jams_run();
-  jams_finish();
+
+  auto program_args = jams::parse_args(argc, argv);
+
+  jams::initialize_simulation(program_args);
+  if (!program_args.setup_only) {
+    jams::run_simulation();
+  }
+  jams::cleanup_simulation();
+
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Added neater code for parsing command line arguments to JAMS.

The new flag "--setup-only" runs the initialization routines to create the system but doesn't run the solver. This will be used for checking config files and input without actually having to do a simulation.

I also moved some of the main JAMS routines into the JAMS namespace.