### PR TITLE
Fix incorrect spin index in monte carlo

### DIFF
--- a/src/jams/solvers/cpu_monte_carlo_metropolis.cc
+++ b/src/jams/solvers/cpu_monte_carlo_metropolis.cc
@@ -323,7 +323,7 @@ void MetropolisMCSolver::initialize(const libconfig::Setting& settings) {
 
       auto deltaE = 0.0;
       for (const auto& ham : hamiltonians_) {
-        deltaE += ham->calculate_one_spin_energy_difference(n, s_initial, s_final);
+        deltaE += ham->calculate_one_spin_energy_difference(spin_index, s_initial, s_final);
       }
 
       if (uniform_distribution(random_generator_) < exp(min(0.0, -deltaE * beta))) {


### PR DESCRIPTION
When adding the code to toggle between ‘typewriter’ indexing and random indexing an index was missed so energy differences were calculated with the wrong spin.