### PR TITLE
Fix sparse matrix symmetry check for dipole

### DIFF
--- a/src/jams/containers/sparse_matrix_builder.h
+++ b/src/jams/containers/sparse_matrix_builder.h
@@ -6,6 +6,13 @@
 #include "jams/containers/sparse_matrix.h"
 
 namespace jams {
+
+    enum class SparseMatrixSymmetryCheck {
+        None,
+        Symmetric,
+        StructurallySymmetric
+    };
+
     template<typename T>
     class SparseMatrix<T>::Builder {
     public:

--- a/src/jams/hamiltonian/dipole_tensor.cc
+++ b/src/jams/hamiltonian/dipole_tensor.cc
@@ -37,10 +37,11 @@ DipoleHamiltonianTensor::DipoleHamiltonianTensor(const libconfig::Setting &setti
   const double prefactor = kVacuumPermeadbility * kBohrMagneton / (4 * kPi * pow(::lattice->parameter(), 3));
 
   for (auto i = 0; i < globals::num_spins; ++i) {
-    for (auto j = 0; j < globals::num_spins; ++j) {
+    for (auto j = i; j < globals::num_spins; ++j) {
       // loop over periodic images of the simulation lattice
       // this means r_cutoff can be larger than the simulation cell
       Mat3 dipole_tensor = kZeroMat3;
+
       for (auto Lx = -L_max[0]; Lx < L_max[0] + 1; ++Lx) {
         for (auto Ly = -L_max[1]; Ly < L_max[1] + 1; ++Ly) {
           for (auto Lz = -L_max[2]; Lz < L_max[2] + 1; ++Lz) {
@@ -67,14 +68,13 @@ DipoleHamiltonianTensor::DipoleHamiltonianTensor(const libconfig::Setting &setti
                     pow(r_abs, 3);
               }
             }
-
           }
         }
       }
-      insert_interaction_tensor(i, j, prefactor * dipole_tensor);
 
+      insert_interaction_tensor(i, j, prefactor * dipole_tensor);
+      insert_interaction_tensor(j, i, prefactor * dipole_tensor);
     }
   }
-
-  finalize();
+  finalize(jams::SparseMatrixSymmetryCheck::None);
 }

--- a/src/jams/hamiltonian/exchange.cc
+++ b/src/jams/hamiltonian/exchange.cc
@@ -89,7 +89,7 @@ ExchangeHamiltonian::ExchangeHamiltonian(const libconfig::Setting &settings, con
     }
   }
 
-  finalize();
+  finalize(jams::SparseMatrixSymmetryCheck::Symmetric);
 }
 
 const jams::InteractionList<Mat3,2> &ExchangeHamiltonian::neighbour_list() const {

--- a/src/jams/hamiltonian/exchange_functional.cc
+++ b/src/jams/hamiltonian/exchange_functional.cc
@@ -41,7 +41,7 @@ ExchangeFunctionalHamiltonian::ExchangeFunctionalHamiltonian(const libconfig::Se
   cout << "  total interactions " << jams::fmt::integer << counter << "\n";
   cout << "  average interactions per spin " << jams::fmt::decimal << counter / double(globals::num_spins) << "\n";
 
-  finalize();
+  finalize(jams::SparseMatrixSymmetryCheck::Symmetric);
 }
 
 double ExchangeFunctionalHamiltonian::functional_exp(const double rij, const double J0, const double r0, const double sigma){

--- a/src/jams/hamiltonian/exchange_neartree.cc
+++ b/src/jams/hamiltonian/exchange_neartree.cc
@@ -160,5 +160,5 @@ ExchangeNeartreeHamiltonian::ExchangeNeartreeHamiltonian(const libconfig::Settin
   cout << "  total interactions " << counter << "\n";
   cout << "  average interactions per spin " << counter / double(globals::num_spins) << "\n";
 
-  finalize();
+  finalize(jams::SparseMatrixSymmetryCheck::Symmetric);
 }

--- a/src/jams/hamiltonian/sparse_interaction.cc
+++ b/src/jams/hamiltonian/sparse_interaction.cc
@@ -92,7 +92,7 @@ double SparseInteractionHamiltonian::calculate_total_energy() {
   return 0.5 * total_energy;
 }
 
-void SparseInteractionHamiltonian::finalize() {
+void SparseInteractionHamiltonian::finalize(jams::SparseMatrixSymmetryCheck symmetry_check) {
   assert(!is_finalized_);
 
   if (debug_is_enabled()) {
@@ -101,10 +101,21 @@ void SparseInteractionHamiltonian::finalize() {
     os.close();
   }
 
-  if (!sparse_matrix_builder_.is_symmetric()) {
-    throw std::runtime_error("sparse matrix for " + name_ + " is not symmetric");
+  switch(symmetry_check) {
+    case jams::SparseMatrixSymmetryCheck::None:
+      break;
+    case jams::SparseMatrixSymmetryCheck::Symmetric:
+      if (!sparse_matrix_builder_.is_symmetric()) {
+        throw std::runtime_error("sparse matrix for " + name_ + " is not symmetric");
+      }
+      break;
+    case jams::SparseMatrixSymmetryCheck::StructurallySymmetric:
+      if (!sparse_matrix_builder_.is_structurally_symmetric()) {
+        throw std::runtime_error("sparse matrix for " + name_ + " is not structurally symmetric");
+      }
+      break;
   }
-  
+
   interaction_matrix_ = sparse_matrix_builder_
       .set_format(jams::SparseMatrixFormat::CSR)
       .build();

--- a/src/jams/hamiltonian/sparse_interaction.h
+++ b/src/jams/hamiltonian/sparse_interaction.h
@@ -29,7 +29,7 @@ public:
 protected:
     void insert_interaction_scalar(const int i, const int j, const double &value);
     void insert_interaction_tensor(const int i, const int j, const Mat3 &value);
-    void finalize();
+    void finalize(jams::SparseMatrixSymmetryCheck symmetry_check);
 
 private:
     bool is_finalized_ = false;


### PR DESCRIPTION
The exchange sparse matrices are symmetric because each 3x3 tensor is skew-symmetric in the off-diagonal components.

The dipole tensors are not nessecarily symmetric so the sparse matrix is not symmetric. We can instead use the ij symmetry when we construct the matrix to ensure it is symmetric.