### PR TITLE
Allow neutron scattering without form factors

### DIFF
--- a/src/jams/monitors/neutron_scattering.cc
+++ b/src/jams/monitors/neutron_scattering.cc
@@ -24,7 +24,12 @@ using Complex = std::complex<double>;
 
 NeutronScatteringMonitor::NeutronScatteringMonitor(const Setting &settings)
 : SpectrumBaseMonitor(settings) {
-  configure_form_factors(settings["form_factor"]);
+
+  // default to 1.0 in case no form factor is given in the settings
+  fill(neutron_form_factors_.resize(lattice->num_motif_atoms(), num_kpoints()), 1.0);
+  if (settings.exists("form_factor")) {
+    configure_form_factors(settings["form_factor"]);
+  }
 
   if (settings.exists("polarizations")) {
     configure_polarizations(settings["polarizations"]);

--- a/src/jams/monitors/neutron_scattering_no_lattice.cc
+++ b/src/jams/monitors/neutron_scattering_no_lattice.cc
@@ -24,6 +24,8 @@ NeutronScatteringNoLatticeMonitor::NeutronScatteringNoLatticeMonitor(const libco
 
   config_optional(settings, "rspace_windowing", do_rspace_windowing_);
 
+  // default to 1.0 in case no form factor is given in the settings
+  fill(neutron_form_factors_.resize(lattice->num_materials(), num_k_), 1.0);
   if (settings.exists("form_factor")) {
     configure_form_factors(settings["form_factor"]);
   }


### PR DESCRIPTION
Previously form factors were required in the settings. Now they are optional.