### PR TITLE
Allow interaction vector to an array [] or list ()

### DIFF
--- a/src/jams/core/interactions.cc
+++ b/src/jams/core/interactions.cc
@@ -174,11 +174,11 @@ discover_interaction_setting_format(Setting& setting) {
 
   }
 
-  if (!setting[0][2].isArray()) {
+  if (!(setting[0][2].isArray() || setting[0][2].isList())) {
     throw runtime_error("interaction vector format is incorrect");
   }
 
-  if (!((setting[0][3].isArray() && setting[0][3].getLength() == 9) || setting[0][3].isNumber())) {
+  if (!(((setting[0][3].isArray() || setting[0][3].isList()) && setting[0][3].getLength() == 9) || setting[0][3].isNumber())) {
     throw runtime_error("interaction energy format is incorrect");
   }
 


### PR DESCRIPTION
Before we only accepted libconfig arrays like [0.0, 0.0, 1.0], but it's annoying to keep remembering when we want a list or an array and there is no reason we can't also use an array like (0.0, 0.0 1.0) for all arrays in JAMS. I think this is the only point where we explicitly check if it is an array or a list.