### PR TITLE
Increase width for decimal formatting

### DIFF
--- a/src/jams/helpers/output.h
+++ b/src/jams/helpers/output.h
@@ -26,7 +26,7 @@ namespace jams {
         }
 
         inline std::ostream &decimal(std::ostream &os) {
-          return os << std::setprecision(6) << std::setw(10) << std::fixed << std::right;
+          return os << std::setprecision(6) << std::setw(16) << std::fixed << std::right;
         }
 
         inline std::ostream &sci(std::ostream &os) {


### PR DESCRIPTION
Numbers from 100 already filled the width because the numbers before the decimal point aren’t part of the precision. We can now fit numbers upto  1,000,000.