### PR TITLE
Add --version flag for printing semantic version

### DIFF
--- a/cmake/Templates/version.h.in
+++ b/cmake/Templates/version.h.in
@@ -14,9 +14,10 @@
 
 namespace jams {
     namespace build {
-        constexpr auto version = "@VERSION@";
+        constexpr auto version = "@VERSION@"; // this is the version specified in the jams CMake file
         constexpr auto type = "@CMAKE_BUILD_TYPE@";
         constexpr auto time = "@JAMS_BUILD_TIME@";
+        constexpr auto description = "@JAMS_GIT_DESCRIPTION@"; // this is the git description where the version comes from a tag
         constexpr auto branch = "@JAMS_GIT_BRANCH@";
         constexpr auto hash = "@JAMS_GIT_COMMIT_HASH@";
         constexpr auto option_cuda = "@JAMS_BUILD_CUDA@";

--- a/cmake/Utils.cmake
+++ b/cmake/Utils.cmake
@@ -37,10 +37,22 @@ function(jams_extract_git_info)
         if(NOT ${__git_result} EQUAL 0)
             set(JAMS_GIT_COMMIT_HASH "unknown")
         endif()
+
+        execute_process(
+                COMMAND ${GIT_EXECUTABLE} describe --tags --long --dirty
+                ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE
+                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+                OUTPUT_VARIABLE JAMS_GIT_DESCRIPTION
+                RESULT_VARIABLE __git_result)
+
+        if(NOT ${__git_result} EQUAL 0)
+            set(JAMS_GIT_DESCRIPTION "unknown")
+        endif()
     endif()
 
     set(JAMS_GIT_BRANCH ${JAMS_GIT_BRANCH} PARENT_SCOPE)
     set(JAMS_GIT_COMMIT_HASH ${JAMS_GIT_COMMIT_HASH} PARENT_SCOPE)
+    set(JAMS_GIT_DESCRIPTION ${JAMS_GIT_DESCRIPTION} PARENT_SCOPE)
 endfunction()
 
 function(jams_set_fast_math target)

--- a/src/jams/core/args.cc
+++ b/src/jams/core/args.cc
@@ -11,6 +11,11 @@ namespace jams {
     }
 
     void process_flag(const std::string& flag, ProgramArgs& program_args) {
+      if (flag == "--version") {
+        program_args.version_only = true;
+        return;
+      }
+
       if (flag == "--setup-only") {
         program_args.setup_only = true;
         return;

--- a/src/jams/core/args.h
+++ b/src/jams/core/args.h
@@ -11,6 +11,7 @@
 namespace jams {
 
     struct ProgramArgs {
+        bool        version_only      = false;
         bool        setup_only        = false;
         std::string output_path = "";
         std::string simulation_name = "";

--- a/src/jams/core/jams++.cc
+++ b/src/jams/core/jams++.cc
@@ -192,6 +192,7 @@ namespace jams {
 
     void initialize_simulation(const jams::ProgramArgs &program_args) {
       try {
+        cout << "\nJAMS++ " << jams::build::version << std::endl;
         cout << jams::section("build info") << std::endl;
         cout << jams::build_info();
         cout << jams::section("run info") << std::endl;

--- a/src/jams/helpers/utils.h
+++ b/src/jams/helpers/utils.h
@@ -228,6 +228,25 @@ inline std::vector<std::string> split(const std::string& s, const std::string& d
   return result;
 }
 
+// Convert a string containing the output of git describe --tags --long into a
+// semantic version string
+inline std::string semantic_version(const std::string &git_description) {
+  auto parts = split(git_description, "-");
+
+  // this will be tag+commits_ahead.hash[.dirty], substr removes the 'g' at the front
+  // of the hash which only stands for 'git' and is not part of the hash. If the
+  // repo has uncommitted changes it is  marked with '.dirty' at the end
+  if (parts.size() == 3) {
+    return parts[0] + "+" + parts[1] + "." + parts[2].substr(1);
+  } else if (parts.size() == 4) {
+    return parts[0] + "+" + parts[1] + "." + parts[2].substr(1) + "." + parts[3];
+  }
+
+  // git description is not properly formatted to parse for semantic versioning
+  // so just return as is.
+  return git_description;
+}
+
 inline std::string memory_in_natural_units(std::size_t size) {
   std::map<int, std::string> byte_sizes;
   byte_sizes[0] = "B";

--- a/src/jams/main.cc
+++ b/src/jams/main.cc
@@ -7,9 +7,12 @@
 
 int main(int argc, char **argv) {
   jams::output::initialise();
-  std::cout << "\nJAMS++ " << jams::build::version << std::endl;
-
   auto program_args = jams::parse_args(argc, argv);
+
+  if (program_args.version_only) {
+    std::cout << "jams-" << semantic_version(jams::build::description) << std::endl;
+    return EXIT_SUCCESS;
+  }
 
   jams::initialize_simulation(program_args);
   if (!program_args.setup_only) {


### PR DESCRIPTION
This uses git describe and will be in a format like jams-v2.3.1+4.46c24c77 where v2.3.1 is the semantic version, +4  is the number of commits ahead of the version tag and 46c24c77 is the short hast of this commit.