### PR TITLE
Change default exchange energy cutoff

### DIFF
--- a/src/jams/hamiltonian/exchange.cc
+++ b/src/jams/hamiltonian/exchange.cc
@@ -16,7 +16,8 @@ ExchangeHamiltonian::ExchangeHamiltonian(const libconfig::Setting &settings, con
   bool use_symops = true;
   settings.lookupValue("symops", use_symops);
 
-  energy_cutoff_ = 1E-26;  // Joules
+  // this is in the units specified by 'unit_name' in the input
+  energy_cutoff_ = 0.0;
   settings.lookupValue("energy_cutoff", energy_cutoff_);
   cout << "    interaction energy cutoff " << energy_cutoff_ << "\n";
 


### PR DESCRIPTION
The default was set to a value in Joules, but I think we should not ignore anything given by default and only invoke the cutoff if requested.