### PR TITLE
Add build flag to toggle external project updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ endif()
 include(cmake/Utils.cmake)
 ensure_out_of_source_build()
 
+option(JAMS_BUILD_OFFLINE "Build JAMS without updating external dependencies online" OFF)
 option(JAMS_BUILD_OMP "Build JAMS with OpenMP support" OFF)
 option(JAMS_BUILD_CUDA "Build JAMS with CUDA support" ON)
 option(JAMS_BUILD_FASTMATH "Build JAMS with fast math flags" ON)
@@ -18,6 +19,10 @@ project(jams LANGUAGES C CXX)
 
 if (JAMS_BUILD_CUDA)
     enable_language(CUDA)
+endif()
+
+if (${JAMS_BUILD_OFFLINE})
+    set_property(DIRECTORY ${jams_SOURCE_DIR} PROPERTY EP_UPDATE_DISCONNECTED 1)
 endif()
 
 set(CMAKE_CXX_STANDARD 11)
@@ -37,7 +42,7 @@ set(VERSION "${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_PATCH}")
 # github master branch
 set(JAMS_LIBCONFIG_VERSION f53e5de) # https://github.com/hyperrealm/libconfig
 set(JAMS_HIGHFIVE_VERSION v2.1.1)   # https://github.com/BlueBrain/HighFive
-set(JAMS_SPGLIB_VERSION v1.10.4)    # https://github.com/atztogo/spglib
+set(JAMS_SPGLIB_VERSION v1.16.0)    # https://github.com/atztogo/spglib
 set(JAMS_PCG_VERSION v0.98.1)       # https://github.com/imneme/pcg-cpp
 
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)

--- a/cmake/External/gtest.cmake
+++ b/cmake/External/gtest.cmake
@@ -2,7 +2,6 @@ include(${PROJECT_SOURCE_DIR}/cmake/Modules/DownloadProject.cmake)
 
 download_project(PROJ                googletest
                  GIT_REPOSITORY      https://github.com/google/googletest.git
-                 GIT_TAG             master
-                 UPDATE_DISCONNECTED 1)
+                 GIT_TAG             master)
 
 add_subdirectory(${googletest_SOURCE_DIR} ${googletest_BINARY_DIR} EXCLUDE_FROM_ALL)

--- a/cmake/External/highfive.cmake
+++ b/cmake/External/highfive.cmake
@@ -10,7 +10,6 @@ download_project(
         PROJ                HighFive
         GIT_REPOSITORY      https://github.com/BlueBrain/HighFive.git
         GIT_TAG             ${JAMS_HIGHFIVE_VERSION}
-        UPDATE_DISCONNECTED 1
         CMAKE_ARGS          ${PROJ_CMAKE_ARGS}
 )
 

--- a/cmake/External/libconfig.cmake
+++ b/cmake/External/libconfig.cmake
@@ -11,7 +11,6 @@ download_project(
         PROJ                libconfig
         GIT_REPOSITORY      https://github.com/hyperrealm/libconfig.git
         GIT_TAG             ${JAMS_LIBCONFIG_VERSION}
-        UPDATE_DISCONNECTED 1
         CMAKE_ARGS          ${PROJ_CMAKE_ARGS}
 )
 

--- a/cmake/External/pcg.cmake
+++ b/cmake/External/pcg.cmake
@@ -4,7 +4,6 @@ download_project(
         PROJ                pcg
         GIT_REPOSITORY      https://github.com/imneme/pcg-cpp.git
         GIT_TAG             ${JAMS_PCG_VERSION}
-        UPDATE_DISCONNECTED 1
 )
 
 add_library(pcg_builtin INTERFACE)

--- a/cmake/External/spglib.cmake
+++ b/cmake/External/spglib.cmake
@@ -4,7 +4,6 @@ download_project(
         PROJ                spglib
         GIT_REPOSITORY      https://github.com/atztogo/spglib.git
         GIT_TAG             ${JAMS_SPGLIB_VERSION}
-        UPDATE_DISCONNECTED 1
 )
 
 add_subdirectory(${spglib_SOURCE_DIR} ${spglib_BINARY_DIR} EXCLUDE_FROM_ALL)


### PR DESCRIPTION
All the projects which were being added using ExternalProject_add had the argument “UPDATE_DISCONNECTED 1” which means they didn’t check for updates when cmake runs. Hence changing the version number in the CMakeLists.txt would not cause a new version to be pulled and built.

Now we use the directory level EP_UPDATE_DISCONNECTED flag to toggle updates on or off using a build flag JAMS_BUILD_OFFLINE. By default we now choose to always check for updates when cmake runs. We are always specifying the version we want (with a git tag or hash) so this will only actually update if we change the version number.