### PR TITLE
Fix missing toggles in sparsematrix

### DIFF
--- a/src/jams/containers/sparse_matrix_builder.h
+++ b/src/jams/containers/sparse_matrix_builder.h
@@ -126,6 +126,8 @@ namespace jams {
 
       assert(row_.size() == col_.size());
       assert(row_.size() == val_.size());
+
+      is_sorted_ = true;
     }
 
     template<typename T>
@@ -145,6 +147,8 @@ namespace jams {
       }
       assert(row_.size() == col_.size());
       assert(row_.size() == val_.size());
+
+      is_merged_ = true;
     }
 
     template<typename T>


### PR DESCRIPTION
These toggles are in as an optimisation to avoid repeated merging or sorting, but we never actually set them after merging or sorting. The code before was safe but potentially expensive.