### PR TITLE
Revert to non stochastic RK4 for Bose thermostat

### DIFF
--- a/cmake/Sources.cmake
+++ b/cmake/Sources.cmake
@@ -121,5 +121,6 @@ set(JAMS_SOURCES_CUDA
         solvers/cuda_ll_lorentzian_rk4.cu
         thermostats/thm_bose_einstein_cuda_srk4.cu
         thermostats/thm_bose_einstein_cuda_srk4_kernel.cuh
+        thermostats/cuda_langevin_bose.cu
         thermostats/cuda_lorentzian.cu
         thermostats/cuda_langevin_white.cc)

--- a/src/jams/core/thermostat.cc
+++ b/src/jams/core/thermostat.cc
@@ -8,6 +8,7 @@
 #include "jams/thermostats/cuda_langevin_white.h"
 #include "jams/thermostats/thm_bose_einstein_cuda_srk4.h"
 #include "jams/thermostats/cuda_lorentzian.h"
+#include "jams/thermostats/cuda_langevin_bose.h"
 
 #include <string>
 #include <stdexcept>
@@ -23,7 +24,10 @@ Thermostat* Thermostat::create(const std::string &thermostat_name) {
       return new CudaLangevinWhiteThermostat(temperature, 0.0, globals::num_spins);
   }
   if (capitalize(thermostat_name) == "LANGEVIN-BOSE-GPU" ||capitalize(thermostat_name) == "CUDA_LANGEVIN_COTH") {
-      return new jams::BoseEinsteinCudaSRK4Thermostat(temperature, 0.0, globals::num_spins);
+    return new CudaLangevinBoseThermostat(temperature, 0.0, globals::num_spins);
+  }
+  if (capitalize(thermostat_name) == "LANGEVIN-BOSE-SRK4-GPU") {
+    return new jams::BoseEinsteinCudaSRK4Thermostat(temperature, 0.0, globals::num_spins);
   }
   if (capitalize(thermostat_name) == "LANGEVIN-LORENTZIAN-GPU" || capitalize(thermostat_name) == "LANGEVIN-ARBITRARY-GPU" ||capitalize(thermostat_name) == "CUDA_LANGEVIN_ARBITRARY") {
     return new CudaLorentzianThermostat(temperature, 0.0, globals::num_spins);

--- a/src/jams/thermostats/cuda_langevin_bose.cu
+++ b/src/jams/thermostats/cuda_langevin_bose.cu
@@ -1,0 +1,142 @@
+// Copyright 2014 Joseph Barker. All rights reserved.
+
+#include <cmath>
+#include <string>
+#include <iomanip>
+#include <random>
+#include <mutex>
+
+#include "jams/helpers/utils.h"
+#include "jams/cuda/cuda_array_kernels.h"
+
+#include "cuda_langevin_bose.h"
+#include "cuda_langevin_bose_kernel.h"
+
+#include "jams/core/solver.h"
+#include "jams/core/globals.h"
+#include "jams/core/lattice.h"
+#include "jams/core/solver.h"
+#include "jams/cuda/cuda_array_kernels.h"
+#include "jams/helpers/consts.h"
+#include "jams/helpers/error.h"
+#include "jams/helpers/random.h"
+#include "jams/helpers/utils.h"
+#include "jams/cuda/cuda_common.h"
+#include "jams/monitors/magnetisation.h"
+#include "jams/thermostats/cuda_langevin_bose.h"
+#include "jams/thermostats/cuda_langevin_bose_kernel.h"
+
+using namespace std;
+
+CudaLangevinBoseThermostat::CudaLangevinBoseThermostat(const double &temperature, const double &sigma, const int num_spins)
+: Thermostat(temperature, sigma, num_spins),
+  debug_(false)
+  {
+   cout << "\n  initialising CUDA Langevin semi-quantum noise thermostat\n";
+
+   config->lookupValue("thermostat.zero_point", do_zero_point_);
+
+   double t_warmup = 1e-10 / 1e-12; // 0.1 ns
+   config->lookupValue("thermostat.warmup_time", t_warmup);
+
+   omega_max_ = 25.0 * kTwoPi;
+   config->lookupValue("thermostat.w_max", omega_max_);
+
+   double dt_thermostat = double(::config->lookup("solver.t_step")) / 1e-12;
+   delta_tau_ = (dt_thermostat * kBoltzmannIU) / kHBarIU;
+
+   cout << "    omega_max (THz) " << omega_max_ / (kTwoPi) << "\n";
+   cout << "    hbar*w/kB " << (kHBarIU * omega_max_) / (kBoltzmannIU) << "\n";
+   cout << "    t_step " << dt_thermostat << "\n";
+   cout << "    delta tau " << delta_tau_ << "\n";
+
+   cout << "    initialising CUDA streams\n";
+
+   if (cudaStreamCreate(&dev_stream_) != cudaSuccess) {
+     jams_die("Failed to create CUDA stream in CudaLangevinBoseThermostat");
+   }
+
+   if (cudaStreamCreate(&dev_curand_stream_) != cudaSuccess) {
+     jams_die("Failed to create CURAND stream in CudaLangevinBoseThermostat");
+   }
+
+   cout << "    initialising CURAND\n";
+
+   CHECK_CURAND_STATUS(curandSetStream(jams::instance().curand_generator(), dev_curand_stream_));
+   CHECK_CURAND_STATUS(curandGenerateNormalDouble(jams::instance().curand_generator(), eta0_.device_data(), eta0_.size(), 0.0, 1.0));
+   CHECK_CURAND_STATUS(curandGenerateNormalDouble(jams::instance().curand_generator(), eta1a_.device_data(), eta1a_.size(), 0.0, 1.0));
+   CHECK_CURAND_STATUS(curandGenerateNormalDouble(jams::instance().curand_generator(), eta1b_.device_data(), eta1b_.size(), 0.0, 1.0));
+
+    for (int i = 0; i < num_spins; ++i) {
+      for (int j = 0; j < 3; ++j) {
+        sigma_(i,j) = (kBoltzmannIU) * sqrt((2.0 * globals::alpha(i))
+                                            / (kHBarIU * globals::gyro(i) * globals::mus(i)));
+      }
+    }
+
+   num_warm_up_steps_ = static_cast<unsigned>(t_warmup / dt_thermostat);
+
+
+  zero(zeta5_.resize(num_spins * 3));
+  zero(zeta5p_.resize(num_spins * 3));
+  zero(zeta6_.resize(num_spins * 3));
+  zero(zeta6p_.resize(num_spins * 3));
+  zero(eta1a_.resize(2 * num_spins * 3));
+  zero(eta1b_.resize(2 * num_spins * 3));
+
+  if (do_zero_point_) {
+    zero(zeta0_.resize(4 * num_spins * 3));
+    zero(eta0_.resize(4 * num_spins * 3));
+  }
+}
+
+void CudaLangevinBoseThermostat::update() {
+  if (!is_warmed_up_) {
+    is_warmed_up_ = true;
+    warmup(num_warm_up_steps_);
+  }
+
+  int block_size = 96;
+  int grid_size = (globals::num_spins3 + block_size - 1) / block_size;
+
+  const double reduced_omega_max = (kHBarIU * omega_max_) / (kBoltzmannIU * this->temperature());
+  const double reduced_delta_tau = delta_tau_ * this->temperature();
+  const double temperature = this->temperature();
+
+  swap(eta1a_, eta1b_);
+  CHECK_CURAND_STATUS(curandSetStream(jams::instance().curand_generator(), dev_curand_stream_));
+  CHECK_CURAND_STATUS(curandGenerateNormalDouble(jams::instance().curand_generator(), eta1a_.device_data(), eta1a_.size(), 0.0, 1.0));
+
+  bose_coth_stochastic_process_cuda_kernel<<<grid_size, block_size, 0, dev_stream_ >>> (
+    noise_.device_data(), zeta5_.device_data(), zeta5p_.device_data(), zeta6_.device_data(), zeta6p_.device_data(),
+    eta1b_.device_data(), sigma_.device_data(), reduced_delta_tau, temperature, reduced_omega_max, globals::num_spins3);
+  DEBUG_CHECK_CUDA_ASYNC_STATUS;
+
+  if (do_zero_point_) {
+    CHECK_CURAND_STATUS(curandSetStream(jams::instance().curand_generator(), dev_curand_stream_));
+    CHECK_CURAND_STATUS(curandGenerateNormalDouble(jams::instance().curand_generator(), eta0_.device_data(), eta0_.size(), 0.0, 1.0));
+
+    bose_zero_point_stochastic_process_cuda_kernel <<< grid_size, block_size, 0, dev_stream_ >>> (
+        noise_.device_data(), zeta0_.device_data(), eta0_.device_data(), sigma_.device_data(), reduced_delta_tau,
+        temperature, reduced_omega_max, globals::num_spins3);
+    DEBUG_CHECK_CUDA_ASYNC_STATUS;
+  }
+}
+
+CudaLangevinBoseThermostat::~CudaLangevinBoseThermostat() {
+  if (dev_stream_ != nullptr) {
+    cudaStreamDestroy(dev_stream_);
+  }
+
+  if (dev_curand_stream_ != nullptr) {
+    cudaStreamDestroy(dev_curand_stream_);
+  }
+}
+
+void CudaLangevinBoseThermostat::warmup(const unsigned steps) {
+  cout << "warming up thermostat " << steps << " steps @ " << this->temperature() << "K" << std::endl;
+
+  for (auto i = 0; i < steps; ++i) {
+    update();
+  }
+}

--- a/src/jams/thermostats/cuda_langevin_bose.h
+++ b/src/jams/thermostats/cuda_langevin_bose.h
@@ -1,0 +1,51 @@
+// Copyright 2014 Joseph Barker. All rights reserved.
+
+// This thermostat implementation is designed to reproduce a semiquantum thermostat
+// which has a coth(omega) frequency dependence.
+
+#ifndef JAMS_CUDA_THERMOSTAT_LANGEVIN_BOSE_H
+#define JAMS_CUDA_THERMOSTAT_LANGEVIN_BOSE_H
+
+#if HAS_CUDA
+
+#include <curand.h>
+#include <fstream>
+#include <mutex>
+
+#include "jams/core/thermostat.h"
+
+class CudaLangevinBoseThermostat : public Thermostat {
+ public:
+  CudaLangevinBoseThermostat(const double &temperature, const double &sigma, const int num_spins);
+  ~CudaLangevinBoseThermostat();
+
+  void update();
+
+  // override the base class implementation
+  const double* device_data() { return noise_.device_data(); }
+
+ private:
+
+    void warmup(const unsigned steps);
+
+    bool debug_;
+    bool do_zero_point_ = false;
+    bool is_warmed_up_ = false;
+    unsigned num_warm_up_steps_ = 0;
+
+    jams::MultiArray<double, 1> zeta0_;
+    jams::MultiArray<double, 1> zeta5_;
+    jams::MultiArray<double, 1> zeta5p_;
+    jams::MultiArray<double, 1> zeta6_;
+    jams::MultiArray<double, 1> zeta6p_;
+    jams::MultiArray<double, 1> eta0_;
+    jams::MultiArray<double, 1> eta1a_;
+    jams::MultiArray<double, 1> eta1b_;
+    cudaStream_t                dev_stream_ = nullptr;
+    cudaStream_t                dev_curand_stream_ = nullptr;
+    double                      delta_tau_;
+    double                      omega_max_;
+};
+
+#endif  // CUDA
+#endif  // JAMS_CUDA_THERMOSTAT_LANGEVIN_BOSE_H

--- a/src/jams/thermostats/cuda_langevin_bose_kernel.h
+++ b/src/jams/thermostats/cuda_langevin_bose_kernel.h
@@ -1,0 +1,188 @@
+// Copyright 2014 Joseph Barker. All rights reserved.
+
+#ifndef JAMS_CUDA_THERMOSTAT_LANGEVIN_BOSE_KERNEL_H
+#define JAMS_CUDA_THERMOSTAT_LANGEVIN_BOSE_KERNEL_H
+
+__device__ void linear_ode(const double A[4], const double eta[4], const double z[4], double f[4]) {
+  for (auto i = 0; i < 4; ++i) {
+    f[i] = A[i] * (eta[i] - z[i]);
+  }
+}
+
+__device__ void bose_ode(const double A[2], const double eta[2], const double z[2], double f[2]) {
+  f[0] = z[1];
+  f[1] = eta[0] - A[1] * A[1] * z[0] - A[0] * z[1];
+}
+
+template<unsigned N>
+__device__ void
+rk4_vectored(void ode(const double[N], const double[N], const double[N], double[N]), const double h, const double A[2],
+             const double eta[2], double z[2]) {
+  double k1[N], k2[N], k3[N], k4[N], f[N];
+  double u[N];
+
+  for (auto i = 0; i < N; ++i) {
+    u[i] = z[i];
+  }
+
+  ode(A, eta, u, f);
+
+  for (auto i = 0; i < N; ++i) {
+    k1[i] = h * f[i];
+  }
+
+  for (auto i = 0; i < N; ++i) {
+    k1[i] = h * f[i];
+  }
+
+  // K2
+  for (auto i = 0; i < N; ++i) {
+    u[i] = z[i] + 0.5 * k1[i];
+  }
+
+  ode(A, eta, u, f);
+
+  for (auto i = 0; i < N; ++i) {
+    k2[i] = h * f[i];
+  }
+
+  // K3
+  for (auto i = 0; i < N; ++i) {
+    u[i] = z[i] + 0.5 * k2[i];
+  }
+
+  ode(A, eta, u, f);
+
+  for (auto i = 0; i < N; ++i) {
+    k3[i] = h * f[i];
+  }
+
+  // K4
+  for (auto i = 0; i < N; ++i) {
+    u[i] = z[i] + k3[i];
+  }
+
+  ode(A, eta, u, f);
+
+  for (auto i = 0; i < N; ++i) {
+    k4[i] = h * f[i];
+  }
+
+  for (auto i = 0; i < N; ++i) {
+    z[i] = z[i] + (k1[i] + 2.0 * k2[i] + 2.0 * k3[i] + k4[i]) / 6.0;
+  }
+}
+
+__global__ void bose_zero_point_stochastic_process_cuda_kernel
+        (
+                double *noise,
+                double *zeta,
+                const double *eta,
+                const double *sigma,
+                const double h,
+                const double T,
+                const double w_m,
+                const int N
+        ) {
+
+  const int x = blockIdx.x * blockDim.x + threadIdx.x;
+  if (x < N) {
+
+    const double c[4] =
+            {1.043576 * w_m,
+             0.177222 * w_m,
+             0.050319 * w_m,
+             0.010241 * w_m};
+
+
+    const double lambda[4] =
+            {1.763817 * w_m,
+             0.394613 * w_m,
+             0.103506 * w_m,
+             0.015873 * w_m};
+
+    double z[4];
+    for (auto i = 0; i < 4; ++i) {
+      z[i] = zeta[4*x + i];
+    }
+
+    double e[4];
+    for (auto i = 0; i < 4; ++i) {
+      e[i] = eta[4*x + i] * sqrt(2.0 / (lambda[i] * h));
+    }
+
+    rk4_vectored<4>(linear_ode, h, lambda, e, z);
+
+    for (auto i = 0; i < 4; ++i) {
+      zeta[4 * x + i] = z[i];
+    }
+
+    double s0 = 0.0;
+    for (auto i = 0; i < 4; ++i) {
+      s0 += c[i] * (e[i] - z[i]);
+    }
+
+    noise[x] += T * sigma[x] * s0;
+  }
+}
+
+
+__global__ void bose_coth_stochastic_process_cuda_kernel
+        (
+                double *noise,
+                double *zeta5,
+                double *zeta5p,
+                double *zeta6,
+                double *zeta6p,
+                const double *eta,
+                const double *sigma,
+                const double h,
+                const double T,
+                const double w_m,
+                const int N
+        ) {
+  const int x = blockIdx.x * blockDim.x + threadIdx.x;
+  if (x < N) {
+
+    double s1 = 0.0;
+    double e[2], z[2], gamma_omega[2];
+
+    gamma_omega[0] = 5.0142;
+    gamma_omega[1] = 2.7189;
+
+    e[0] = eta[x] * sqrt(2.0 * gamma_omega[0] / h);
+    e[1] = 0.0;
+
+    z[0] = zeta5[x];
+    z[1] = zeta5p[x];
+
+    rk4_vectored<2>(bose_ode, h, gamma_omega, e, z);
+
+    zeta5[x] = z[0];
+    zeta5p[x] = z[1];
+
+    s1 += 1.8315 * z[0];
+
+    //-------------------------------------------------
+
+    gamma_omega[0] = 3.2974;
+    gamma_omega[1] = 1.2223;
+
+    e[0] = eta[N + x] * sqrt(2.0 * gamma_omega[0] / h);
+    e[1] = 0.0;
+
+    z[0] = zeta6[x];
+    z[1] = zeta6p[x];
+
+    rk4_vectored<2>(bose_ode, h, gamma_omega, e, z);
+
+    zeta6[x] = z[0];
+    zeta6p[x] = z[1];
+
+    s1 += 0.3429 * z[0];
+
+    noise[x] = T * sigma[x] * s1;
+  }
+}
+
+#endif  // JAMS_CUDA_THERMOSTAT_LANGEVIN_BOSE_KERNEL_H

--- a/src/jams/thermostats/thm_bose_einstein_cuda_srk4.cu
+++ b/src/jams/thermostats/thm_bose_einstein_cuda_srk4.cu
@@ -19,6 +19,8 @@ jams::BoseEinsteinCudaSRK4Thermostat::BoseEinsteinCudaSRK4Thermostat(const doubl
 : Thermostat(temperature, sigma, num_spins) {
    std::cout << "\n  initialising CUDA Langevin semi-quantum noise thermostat\n";
 
+   jams_warning("This thermostat is currently broken. Do not use for production work.");
+
    double warmup_time = 100.0e-12;
    config->lookupValue("thermostat.warmup_time", warmup_time);
    warmup_time = warmup_time / 1e-12; // convert into ps

--- a/src/jams/thermostats/thm_bose_einstein_cuda_srk4.h
+++ b/src/jams/thermostats/thm_bose_einstein_cuda_srk4.h
@@ -9,6 +9,10 @@
 #include "jams/containers/multiarray.h"
 #include "jams/cuda/cuda_stream.h"
 
+/// ******************************** WARNING ***********************************
+/// This thermostat is currently broken. Do not use for production work.
+/// ****************************************************************************
+
 /// This implements a thermostat which has the statistics of a Bose-Einstein
 /// distribution which has the correlations
 ///


### PR DESCRIPTION
The stochastic RK4 implementation introduced in v2.9.0 does not give correct results. I've left the code in place, but the config option LANGEVIN-BOSE-GPU will now select the old normal RK4 implementation and LANGEVIN-BOSE-SRK4-GPU will select the new (broken) integrator.