### PR TITLE
Add distance unit conversion for Hamiltonians

### DIFF
--- a/src/jams/core/hamiltonian.h
+++ b/src/jams/core/hamiltonian.h
@@ -68,11 +68,14 @@ public:
     }
 
 protected:
-    std::string input_unit_name_; // name of energy unit in input
-    double input_unit_conversion_ = 1.0; // conversion factor from input energy to JAMS native units
+    std::string input_energy_unit_name_; // name of energy unit in input
+    double input_energy_unit_conversion_ = 1.0; // conversion factor from input energy to JAMS native units
+
+    std::string input_distance_unit_name_; // name of distance unit in input
+    double input_distance_unit_conversion_ = 1.0; // conversion factor from input distance to JAMS native units
 
     jams::MultiArray<double, 1> energy_; // energy of every spin for this Hamiltonian
-    jams::MultiArray<double, 2> field_; // field at every spin for this Hamiltonian
+    jams::MultiArray<double, 2> field_; // field at every spin for this Hamiltonianl
 };
 
 

--- a/src/jams/core/units.h
+++ b/src/jams/core/units.h
@@ -7,7 +7,9 @@
 
 #include <map>
 
-#include "jams/helpers/consts.h"
+#include <jams/helpers/consts.h>
+#include <jams/core/lattice.h>
+#include <jams/core/globals.h>
 
 namespace jams {
     const std::map<std::string, double> internal_energy_unit_conversion = {

--- a/src/jams/hamiltonian/cubic_anisotropy.cc
+++ b/src/jams/hamiltonian/cubic_anisotropy.cc
@@ -106,7 +106,7 @@ CubicHamiltonian::CubicHamiltonian(const Setting &settings, const unsigned int n
     auto type = lattice->atom_material_id(i);
     for (auto j = 0; j < cubic_anisotropies[type].size(); ++j) {
       order_(i, j) = cubic_anisotropies[type][j].order;
-      magnitude_(i, j) = cubic_anisotropies[type][j].energy * input_unit_conversion_;
+      magnitude_(i, j) = cubic_anisotropies[type][j].energy * input_energy_unit_conversion_;
       axis1_(i, j) = cubic_anisotropies[type][j].axis1;
       axis2_(i, j) = cubic_anisotropies[type][j].axis2;
       axis3_(i, j) = cubic_anisotropies[type][j].axis3;

--- a/src/jams/hamiltonian/exchange.cc
+++ b/src/jams/hamiltonian/exchange.cc
@@ -85,8 +85,8 @@ ExchangeHamiltonian::ExchangeHamiltonian(const libconfig::Setting &settings, con
   for (auto n = 0; n < neighbour_list_.size(); ++n) {
     auto i = neighbour_list_[n].first[0];
     auto j = neighbour_list_[n].first[1];
-    auto Jij = input_unit_conversion_ * neighbour_list_[n].second;
-    if (max_abs(Jij) > energy_cutoff_ * input_unit_conversion_ ) {
+    auto Jij = input_energy_unit_conversion_ * neighbour_list_[n].second;
+    if (max_abs(Jij) > energy_cutoff_ * input_energy_unit_conversion_ ) {
       insert_interaction_tensor(i, j, Jij);
     }
   }

--- a/src/jams/hamiltonian/exchange_functional.h
+++ b/src/jams/hamiltonian/exchange_functional.h
@@ -17,10 +17,10 @@ public:
 private:
     using ExchangeFunctionalType = std::function<double(double)>;
 
-    static ExchangeFunctionalType functional_from_settings(const libconfig::Setting &settings);
+    ExchangeFunctionalType functional_from_settings(const libconfig::Setting &settings);
 
-    static void output_exchange_functional(std::ostream &os, const ExchangeFunctionalType &functional, double r_cutoff,
-                                           double delta_r = 0.001);
+    void output_exchange_functional(std::ostream &os, const ExchangeFunctionalType &functional, double r_cutoff,
+                                           double delta_r=0.001);
 
     static double functional_step(double rij, double J0, double r_cut);
 

--- a/src/jams/hamiltonian/exchange_neartree.cc
+++ b/src/jams/hamiltonian/exchange_neartree.cc
@@ -85,7 +85,7 @@ ExchangeNeartreeHamiltonian::ExchangeNeartreeHamiltonian(const libconfig::Settin
         max_radius = outer_radius;
       }
 
-      double jij_value = double(settings["interactions"][i][4]) * input_unit_conversion_;
+      double jij_value = double(settings["interactions"][i][4]) * input_energy_unit_conversion_;
 
       auto type_id_A = lattice->material_id(type_name_A);
       auto type_id_B = lattice->material_id(type_name_B);

--- a/src/jams/hamiltonian/random_anisotropy.cc
+++ b/src/jams/hamiltonian/random_anisotropy.cc
@@ -42,7 +42,7 @@ RandomAnisotropyHamiltonian::RandomAnisotropyHamiltonian(const libconfig::Settin
   vector<RandomAnisotropyProperties> properties;
   for (auto i = 0; i < settings["magnitude"].getLength(); ++i) {
     properties.push_back({
-            double(settings["magnitude"][i]) * input_unit_conversion_,
+                             double(settings["magnitude"][i]) * input_energy_unit_conversion_,
             settings.exists("sigma") ? double(settings["sigma"][i]) : 0.0});
   }
 

--- a/src/jams/hamiltonian/uniaxial_anisotropy.cc
+++ b/src/jams/hamiltonian/uniaxial_anisotropy.cc
@@ -97,14 +97,14 @@ UniaxialHamiltonian::UniaxialHamiltonian(const Setting &settings, const unsigned
   for (const auto& ani : anisotropies) {
     for (auto i = 0; i < globals::num_spins; ++i) {
       if (lattice->atom_motif_position(i) == ani.motif_position) {
-        magnitude_(i) = ani.energy * input_unit_conversion_;
+        magnitude_(i) = ani.energy * input_energy_unit_conversion_;
         for (auto j : {0, 1, 2}) {
           axis_(i, j) = ani.axis[j];
         }
       }
       if (lattice->material_exists(ani.material)) {
         if (lattice->atom_material_id(i) == lattice->material_id(ani.material)) {
-          magnitude_(i) = ani.energy * input_unit_conversion_;
+          magnitude_(i) = ani.energy * input_energy_unit_conversion_;
           for (auto j : {0, 1, 2}) {
             axis_(i, j) = ani.axis[j];
           }

--- a/src/jams/hamiltonian/uniaxial_microscopic_anisotropy.cc
+++ b/src/jams/hamiltonian/uniaxial_microscopic_anisotropy.cc
@@ -28,7 +28,7 @@ UniaxialMicroscopicHamiltonian::UniaxialMicroscopicHamiltonian(const libconfig::
 
     std::vector<double> values(settings["d2z"].getLength());
     for (auto i = 0; i < settings["d2z"].getLength(); ++i) {
-      values[i] = double(settings["d2z"][i]) * input_unit_conversion_;
+      values[i] = double(settings["d2z"][i]) * input_energy_unit_conversion_;
     }
 
     cfg_mca_value.push_back(values);
@@ -42,7 +42,7 @@ UniaxialMicroscopicHamiltonian::UniaxialMicroscopicHamiltonian(const libconfig::
 
     std::vector<double> values(settings["d4z"].getLength());
     for (auto i = 0; i < settings["d4z"].getLength(); ++i) {
-      values[i] = double(settings["d4z"][i]) * input_unit_conversion_;
+      values[i] = double(settings["d4z"][i]) * input_energy_unit_conversion_;
     }
 
     cfg_mca_value.push_back(values);
@@ -56,7 +56,7 @@ UniaxialMicroscopicHamiltonian::UniaxialMicroscopicHamiltonian(const libconfig::
 
     std::vector<double> values(settings["d6z"].getLength());
     for (auto i = 0; i < settings["d6z"].getLength(); ++i) {
-      values[i] = double(settings["d6z"][i]) * input_unit_conversion_;
+      values[i] = double(settings["d6z"][i]) * input_energy_unit_conversion_;
     }
 
     cfg_mca_value.push_back(values);

--- a/src/jams/helpers/defaults.h
+++ b/src/jams/helpers/defaults.h
@@ -23,6 +23,7 @@ namespace jams {
         constexpr auto   physics_module = "empty";
 
         constexpr auto   energy_unit_name = "joules";
+        constexpr auto   distance_unit_name = "lattice_constants";
 
         constexpr int    monitor_output_steps = 100;
         constexpr double monitor_convergence_tolerance = 0.01;


### PR DESCRIPTION
The units for distance can now be specified for Hamiltonians and the conversion factors in the base class allow us to convert to JAMS internal units (lattice constants).