### PR TITLE
Allow interaction checks to be toggled with config

### DIFF
--- a/src/jams/core/interactions.cc
+++ b/src/jams/core/interactions.cc
@@ -16,7 +16,8 @@
 #include "jams/helpers/utils.h"
 #include "jams/helpers/exception.h"
 
-void neighbour_list_strict_checks(const jams::InteractionList<Mat3, 2>& list);
+
+void neighbour_list_checks(const jams::InteractionList<Mat3, 2>& list, const std::vector<InteractionChecks>& checks);
 
 using namespace std;
 using libconfig::Setting;
@@ -396,7 +397,7 @@ neighbour_list_from_interactions(vector<InteractionData> &interactions) {
 }
 
 jams::InteractionList<Mat3, 2>
-generate_neighbour_list(ifstream &file, CoordinateFormat coord_format, bool use_symops, double energy_cutoff, double radius_cutoff) {
+generate_neighbour_list(ifstream &file, CoordinateFormat coord_format, bool use_symops, double energy_cutoff, double radius_cutoff, std::vector<InteractionChecks> checks) {
   auto file_desc = discover_interaction_file_format(file);
   auto interactions = interactions_from_file(file, file_desc);
 
@@ -407,13 +408,13 @@ generate_neighbour_list(ifstream &file, CoordinateFormat coord_format, bool use_
 
   auto nbrs = neighbour_list_from_interactions(interactions);
 
-  neighbour_list_strict_checks(nbrs);
+  neighbour_list_checks(nbrs, checks);
 
   return nbrs;
 }
 
 jams::InteractionList<Mat3, 2>
-generate_neighbour_list(Setting& setting, CoordinateFormat coord_format, bool use_symops, double energy_cutoff, double radius_cutoff) {
+generate_neighbour_list(Setting& setting, CoordinateFormat coord_format, bool use_symops, double energy_cutoff, double radius_cutoff, std::vector<InteractionChecks> checks) {
   auto file_desc = discover_interaction_setting_format(setting);
   auto interactions = interactions_from_settings(setting, file_desc);
 
@@ -424,46 +425,58 @@ generate_neighbour_list(Setting& setting, CoordinateFormat coord_format, bool us
 
   auto nbrs = neighbour_list_from_interactions(interactions);
 
-  neighbour_list_strict_checks(nbrs);
+  neighbour_list_checks(nbrs, checks);
 
   return nbrs;
 }
 
-void neighbour_list_strict_checks(const jams::InteractionList<Mat3, 2>& list) {
+void neighbour_list_checks(const jams::InteractionList<Mat3, 2>& list, const std::vector<InteractionChecks>& checks) {
   using namespace globals;
 
-  // bulk system
-  if (lattice->is_periodic(0) && lattice->is_periodic(1) && lattice->is_periodic(2)) {
-      if (!lattice->has_impurities()) {
-          // check all spins have some neighbours
+
+  for (const auto& check : checks) {
+    switch (check) {
+      case InteractionChecks::kNoZeroMotifNeighbourCount:
         for (auto i = 0; i < num_spins; ++i) {
           if (list.num_interactions(i) == 0) {
-           throw runtime_error("inconsistent neighbour list: zero neighbour");
-         }
-        }
-
-
-          // check number of interactions for each motif position is the same
-          vector<unsigned> motif_position_interactions(lattice->num_motif_atoms());
-          for (auto i = 0; i < lattice->num_motif_atoms(); ++i) {
-              motif_position_interactions[i] = list.num_interactions(i);
+            throw runtime_error(
+                "inconsistent neighbour list: some sites have no neighbours");
           }
+        }
+        break;
+      case InteractionChecks::kIdenticalMotifNeighbourCount:
+        if (lattice->is_periodic(0) && lattice->is_periodic(1) && lattice->is_periodic(2)) {
+            vector<unsigned> motif_position_interactions(
+                lattice->num_motif_atoms());
+            for (auto i = 0; i < lattice->num_motif_atoms(); ++i) {
+              motif_position_interactions[i] = list.num_interactions(i);
+            }
 
-          for (auto i = 0; i < num_spins; ++i) {
+            for (auto i = 0; i < num_spins; ++i) {
               auto pos = lattice->atom_motif_position(i);
               if (list.num_interactions(i) != motif_position_interactions[pos]) {
-                  throw runtime_error("inconsistent neighbour list: motif count");
-              }
+                throw runtime_error(
+                    "inconsistent neighbour list: some sites have different numbers of neighbours for the same motif position");
+            }
           }
+        }
+        break;
+      case InteractionChecks::kIdenticalMotifTotalExchange:
+      if (lattice->is_periodic(0) && lattice->is_periodic(1) && lattice->is_periodic(2)) {
 
-          auto lambda = [](const Mat3& prev, const jams::InteractionList<Mat3, 2>::pair_type& next){ return prev + next.second; };
+          // check diagonal part of J0 is the same for each motif position
+          auto lambda = [](const Mat3 &prev,
+                           const jams::InteractionList<Mat3, 2>::pair_type &next) {
+              return prev + next.second;
+          };
 
-
-        // check diagonal part of J0 is the same for each motif position
-          vector<Mat3> motif_position_total_exchange(lattice->num_motif_atoms(), kZeroMat3);
+          vector<Mat3> motif_position_total_exchange(lattice->num_motif_atoms(),
+                                                     kZeroMat3);
           for (auto i = 0; i < lattice->num_motif_atoms(); ++i) {
-              auto neighbour_list = list.interactions_of(i);
-              motif_position_total_exchange[i] = std::accumulate(neighbour_list.begin(), neighbour_list.end(), kZeroMat3, lambda);
+            auto neighbour_list = list.interactions_of(i);
+            motif_position_total_exchange[i] = std::accumulate(
+                neighbour_list.begin(), neighbour_list.end(), kZeroMat3,
+                lambda);
           }
 
           for (auto i = 0; i < num_spins; ++i) {
@@ -471,13 +484,18 @@ void neighbour_list_strict_checks(const jams::InteractionList<Mat3, 2>& list) {
 
             auto pos = lattice->atom_motif_position(i);
 
-            Mat3 J0 = std::accumulate(neighbour_list.begin(), neighbour_list.end(), kZeroMat3, lambda);
+            Mat3 J0 = std::accumulate(neighbour_list.begin(),
+                                      neighbour_list.end(), kZeroMat3, lambda);
 
-            if (!approximately_equal(diag(J0), diag(motif_position_total_exchange[pos]), 1e-6)){
+            if (!approximately_equal(diag(J0),
+                                     diag(motif_position_total_exchange[pos]),
+                                     1e-6)) {
               throw runtime_error("inconsistent neighbour list: J0");
             }
           }
-      }
+        }
+        break;
+    }
   }
 }
 

--- a/src/jams/core/interactions.h
+++ b/src/jams/core/interactions.h
@@ -40,6 +40,12 @@ inline InteractionFileFormat interaction_file_format_from_string(const std::stri
 // Exchange can be specified isotropic (1 scalar) or a full tensor (9 scalars)
 enum class InteractionType {UNDEFINED, SCALAR, TENSOR};
 
+enum class InteractionChecks {
+    kNoZeroMotifNeighbourCount,    /// < Check no motif positions have zero neighbours
+    kIdenticalMotifNeighbourCount, /// < Check if all motif positions have the same number of neighbours
+    kIdenticalMotifTotalExchange   /// < Check all motif positions have the same total exchange value (based on diagonal part of exchange)
+};
+
 struct InteractionFileDescription {
     InteractionFileDescription() = default;
 
@@ -84,12 +90,14 @@ neighbour_list_from_interactions(std::vector<InteractionData> &interactions);
 jams::InteractionList<Mat3, 2>
 generate_neighbour_list(std::ifstream &file,
         CoordinateFormat coord_format = CoordinateFormat::CARTESIAN, bool use_symops = true,
-        double energy_cutoff = 0.0, double radius_cutoff = 0.0);
+        double energy_cutoff = 0.0, double radius_cutoff = 0.0, std::vector<InteractionChecks> checks = {
+    InteractionChecks::kNoZeroMotifNeighbourCount, InteractionChecks::kIdenticalMotifNeighbourCount, InteractionChecks::kIdenticalMotifTotalExchange});
 
 jams::InteractionList<Mat3, 2>
 generate_neighbour_list(libconfig::Setting& settings,
         CoordinateFormat coord_format = CoordinateFormat::CARTESIAN, bool use_symops = true,
-        double energy_cutoff = 0.0, double radius_cutoff = 0.0);
+        double energy_cutoff = 0.0, double radius_cutoff = 0.0, std::vector<InteractionChecks> checks = {
+    InteractionChecks::kNoZeroMotifNeighbourCount, InteractionChecks::kIdenticalMotifNeighbourCount, InteractionChecks::kIdenticalMotifTotalExchange});
 
 void
 safety_check_distance_tolerance(const double &tolerance);


### PR DESCRIPTION
The 'strict' interaction checks were always performed on interactions read in from the exchange Hamiltonian. However, it is sometimes desirable to disable a check, for example if we are only specifying a subset of exchange interactions in the unit cell with one Hamiltonian because another Hamiltonian will specify the rest.

We can now toggle each check on/off in the exchange settings. By default all checks are enabled.