### PR TITLE
Fix sparse matrix csr builder

### DIFF
--- a/src/jams/containers/sparse_matrix_builder.h
+++ b/src/jams/containers/sparse_matrix_builder.h
@@ -127,6 +127,9 @@ namespace jams {
       assert(row_.size() == col_.size());
       assert(row_.size() == val_.size());
 
+      // check the rows really are sorted
+      assert(std::is_sorted(row_.begin(), row_.end()));
+
       is_sorted_ = true;
     }
 
@@ -178,29 +181,54 @@ namespace jams {
 
       const auto nnz = val_.size();
 
+      // Here row_ is sorted and merged. Merged means that any entries with the
+      // same (row, col) are summed together. But there are still nnz entries
+      // in row_, col_ and val_. Now we need to 'compress' the rows. This means
+      // recording the col, val index that a row starts at into csr_rows.
+      // There is always the possibility that rows contain no values in which
+      // case the index should not increment.
+
       index_container csr_rows(num_rows_ + 1);
 
       csr_rows(0) = 0;
       index_type current_row = 0;
       index_type previous_row = 0;
 
-      for (auto m = 1; m < nnz; ++m) {
-        assert(m < row_.size());
+      for (auto m = 1; m < row_.size(); ++m) {
+
         current_row = row_[m];
+        assert(current_row < num_rows_);
+
+        // We're still compressing this row
         if (current_row == previous_row) {
           continue;
         }
 
         assert(current_row + 1 < csr_rows.size());
 
-        // fill in row array including any missing entries where there were no row,col values
-        for (auto i = previous_row+1; i < current_row+1; ++i) {
+        // Current row is not the same as the previous row
+
+        // Find the difference between the current row and the previous
+        // row. This may not be 1 in the case where there are empty rows in
+        // the sparse matrix.
+        for (auto i = previous_row + 1; i < current_row + 1; ++i) {
           csr_rows(i) = m;
         }
 
         previous_row = current_row;
       }
-      csr_rows(num_rows_) = nnz;
+
+      // We may not have reached the end of the rows if there are empty rows
+      // at the bottom of the matrix. So we need to keep looping until the
+      // end and insert nnz.
+      for (auto i = previous_row + 1; i < num_rows_ + 1; ++i) {
+        csr_rows(i) = nnz;
+      }
+
+      assert(csr_rows(0) == 0);
+      assert(csr_rows(num_rows_) == nnz);
+      assert(std::is_sorted(csr_rows.begin(), csr_rows.end()));
+
       jams::util::force_deallocation(row_);
       index_container csr_cols(col_.begin(), col_.end());
       jams::util::force_deallocation(col_);


### PR DESCRIPTION
Empty rows at the bottom of the matrix were not handled in the 'compression' of the rows meaning the indices were zero rather than nnz.

This is now corrected and additional asserts are in place to catch any breaking of the strict sorted order of the csr rows.

Fixes #147 