### PR TITLE
Rename some vector operations

### DIFF
--- a/src/jams/containers/cell.cc
+++ b/src/jams/containers/cell.cc
@@ -30,7 +30,7 @@ Vec3 minimum_image_bruteforce(const Cell& cell, const Vec3& r_i_cart, const Vec3
     for (auto k = -N_b; k < N_b + 1; ++k) {
       for (auto l = -N_c; l < N_c + 1; ++l) {
         auto ds = r_ij + h * cell.a() + k * cell.b() + l * cell.c();
-        if (norm_sq(ds) < norm_sq(r_ij_min)) {
+        if (norm_squared(ds) < norm_squared(r_ij_min)) {
           r_ij_min = ds;
         }
       }

--- a/src/jams/containers/mat3.h
+++ b/src/jams/containers/mat3.h
@@ -224,7 +224,7 @@ inline Mat3 rotation_matrix_between_vectors(const Vec3 &a, const Vec3 &b) {
   const auto c = dot(ua,ub);
 
   // check if a == b or a == -b
-  if (approximately_zero(norm_sq(v), 1e-12)) {
+  if (approximately_zero(norm_squared(v), 1e-12)) {
     // this is a shortcut for a == b and necessary
     // for a == -b where Rodrigues's formula will fail
     // return either I or -I

--- a/src/jams/containers/vec3.h
+++ b/src/jams/containers/vec3.h
@@ -90,6 +90,8 @@ inline constexpr auto operator/=(Vec<T1,3>& lhs, const T2& rhs) -> Vec<decltype(
   return {lhs[0] /= rhs, lhs[1] /= rhs, lhs[2] /= rhs};
 }
 
+
+/// Returns true if all components of the Vec are exactly equal, false otherwise.
 template <typename T>
 inline constexpr bool equal(const Vec<T,3>& lhs, const Vec<T,3>& rhs) {
   return (lhs[0] == rhs[0]) && (lhs[1] == rhs[1]) && (lhs[2] == rhs[2]);
@@ -110,57 +112,72 @@ inline constexpr auto operator%(const Vec<T,3>& lhs, const Vec<T,3>& rhs) -> Vec
   return {lhs[0] % rhs[0], lhs[1] % rhs[1], lhs[2] % rhs[2]};
 }
 
+
+/// Returns the fused-multiply-add operation elementwise on the vectors a,b and c.
+/// x_k = (a_k * b_k) + c_k
 template <typename T1>
 inline Vec<T1,3> fma(const Vec<T1,3>& a, const Vec<T1,3>& b, const Vec<T1,3>& c) {
   return {std::fma(a[0], b[0], c[0]), std::fma(a[1], b[1], c[1]), std::fma(a[2], b[2], c[2])};
 }
 
+/// Returns the fused-multiply-add operation elementwise on a,b and c where
+/// a is a scalar, b and c are vectors.
+/// x_k = (a * b_k) + c_k
 template <typename T1>
 inline Vec<T1,3> fma(const T1& a, const Vec<T1,3>& b, const Vec<T1,3>& c) {
   return {std::fma(a, b[0], c[0]), std::fma(a, b[1], c[1]), std::fma(a, b[2], c[2])};
 }
 
-
+/// Returns the dot product a . b
 template <typename T1, typename T2>
 inline constexpr auto dot(const Vec<T1,3>& a, const Vec<T2,3>& b) -> decltype(a[0] * b[0]) {
   return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
 }
 
+/// Returns the dot product a . b
 template <typename T1, typename T2>
 inline constexpr auto dot(const Vec<T1,3>& a, const T2 b[3]) -> decltype(a[0] * b[0]) {
   return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
 }
 
+/// Returns the dot product a . b
 template <typename T1, typename T2>
 inline constexpr auto dot(const T1 a[3], const Vec<T2,3>& b) -> decltype(a[0] * b[0]) {
   return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
 }
 
+/// Returns the dot product a . b
 template <typename T1, typename T2>
 inline constexpr auto dot(const T1 a[3], const T2 b[3]) -> decltype(a[0] * b[0]) {
   return a[0] * b[0] + a[1] * b[1] + a[2] * b[2];
 }
 
+/// Returns the dot product of a and b, which is then squared.
 template <typename T1, typename T2>
-inline constexpr auto dot_sq(const Vec<T1,3>& a, const Vec<T2,3>& b) -> decltype(a[0] * b[0]) {
+inline constexpr auto dot_squared(const Vec<T1,3>& a, const Vec<T2,3>& b) -> decltype(a[0] * b[0]) {
   return pow2(dot(a,b));
 }
 
+/// Returns the Euclidean norm \sqrt(x^2 + y^2 + z^2) of the vector.
 template <typename T>
 inline constexpr auto norm(const Vec<T,3>& a) -> decltype(std::sqrt(a[0])) {
   return std::sqrt(dot(a, a));
 }
 
+/// Returns the square of the Euclidean norm (x^2 + y^2 + z^2) of the vector.
 template <typename T>
-inline constexpr T norm_sq(const Vec<T,3>& a) {
+inline constexpr T norm_squared(const Vec<T,3>& a) {
   return dot(a, a);
 }
 
+/// Returns a vector of the absolute values of each component of the argument
+/// vector 'a'.
 template <typename T1>
-inline constexpr auto abs(const Vec<T1,3>& a) -> Vec<decltype(std::abs(a[0])), 3> {
+inline constexpr auto absolute(const Vec<T1,3>& a) -> Vec<decltype(std::abs(a[0])), 3> {
   return {std::abs(a[0]), std::abs(a[1]), std::abs(a[2])};
 }
 
+/// Returns a Vec from the cross product a x b.
 template <typename T1, typename T2>
 inline constexpr auto cross(const Vec<T1,3>& a, const Vec<T2,3>& b) -> Vec<decltype(a[0] * b[0]), 3> {
   return {a[1]*b[2] - a[2]*b[1],
@@ -168,48 +185,66 @@ inline constexpr auto cross(const Vec<T1,3>& a, const Vec<T2,3>& b) -> Vec<declt
           a[0]*b[1] - a[1]*b[0]};
 }
 
+
+/// Returns the magnitude |a x b|^2 using the identity |a||b| - |a.b|^2
 template <typename T1, typename T2>
-inline constexpr auto cross_norm_sq(const Vec<T1,3>& a, const Vec<T2,3>& b) -> decltype(a[0] * b[0]) {
-  return norm_sq(a) * norm_sq(b) - dot_sq(a, b);
+inline constexpr auto cross_norm_squared(const Vec<T1,3>& a, const Vec<T2,3>& b) -> decltype(a[0] * b[0]) {
+  return norm_squared(a) * norm_squared(b) - dot_squared(a, b);
 }
 
+/// Returns the scalar triple product a . (b x c)
 template <typename T1, typename T2, typename T3>
 inline constexpr auto scalar_triple_product(const Vec<T1,3>& a, const Vec<T2,3>& b, const Vec<T3,3>& c) -> decltype(a[0] * b[0] * c[0]) {
   return dot(a, cross(b, c));
 }
 
+/// Returns a Vec from the vector triple product a x (b x c)
 template <typename T1, typename T2, typename T3>
 inline constexpr auto vector_triple_product(const Vec<T1,3>& a, const Vec<T2,3>& b, const Vec<T3,3>& c) -> Vec<decltype(a[0] * b[0] * c[0]), 3> {
   return cross(a, cross(b, c));
 }
 
+/// Returns a Vec with the element wise multiplication of a and b,
+/// c_k = a_k * b_k
 template <typename T1, typename T2>
-inline constexpr auto scale(const Vec<T1,3>& a, const Vec<T2,3>& b) -> Vec<decltype(a[0] * b[0]), 3> {
+inline constexpr auto hadamard_product(const Vec<T1,3>& a, const Vec<T2,3>& b) -> Vec<decltype(a[0] * b[0]), 3> {
   return {a[0] * b[0], a[1] * b[1], a[2] * b[2]};
 }
 
+/// Returns the angle in radians between vector a and b
 template <typename T>
 inline constexpr T angle(const Vec<T,3>& a, const Vec<T,3>& b) {
   return acos(dot(a,b) / (norm(a), norm(b)));
 }
 
+/// Returns a Vec3 in cartesian coordinates (x, y, z) from the polar coordinates
+/// (r, theta, phi), where theta is the polar angle (from z) and phi is the
+/// azimuthal angle (x-y plane, from x). Angles must be in radians.
 inline Vec3 spherical_to_cartesian_vector(const double r, const double theta, const double phi) {
   return {r * sin(theta) * cos(phi), r * sin(theta) * sin(phi), r * cos(theta)};
 }
 
+/// Returns the polar angle in radians of the cartesian vector a. The polar
+/// angle is the angle down from the +z axis.
 inline double polar_angle(const Vec<double,3> a) {
   return acos(a[2]/norm(a));
 }
 
+/// Returns the azimuthal angle in radians of the cartesian vector a. The
+/// azimuthal angle is the angle in the x-y plane starting from x.
 inline double azimuthal_angle(const Vec<double,3> a) {
   return atan2(a[1], a[0]);
 }
 
+/// Returns a unit vector by performing a / |a|. If |a| = 0 the function performs
+/// a zero division and the results will be +infinity.
 template <typename T>
 inline auto normalize(const Vec<T,3>& a) -> Vec<decltype(a[0] / std::abs(a[0])), 3> {
   return a / norm(a);
 }
 
+/// Returns true if all components of a are approximately zero (using a relative
+/// epsilon), false otherwise.
 template <typename T>
 inline bool approximately_zero(const Vec<T,3>& a, const T& epsilon) {
   for (auto n = 0; n < 3; ++n) {
@@ -220,10 +255,11 @@ inline bool approximately_zero(const Vec<T,3>& a, const T& epsilon) {
   return true;
 }
 
-// Vec3 specialization
+/// Performs a safe floating point comparison between vectors a and b to check
+/// for equality. Returns true if all components of a are approximately equal to
+/// b (using a relative epsilon), false otherwise.
 template <typename T>
 inline bool approximately_equal(const Vec<T,3>& a, const Vec<T,3>& b, const T& epsilon) {
-//  return approximately_equal(a[0], b[0], epsilon) && approximately_equal(a[1], b[1], epsilon) && approximately_equal(a[2], b[2], epsilon);
   for (auto n = 0; n < 3; ++n) {
     if (!approximately_equal(a[n], b[n], epsilon)) {
       return false;
@@ -233,7 +269,7 @@ inline bool approximately_equal(const Vec<T,3>& a, const Vec<T,3>& b, const T& e
 }
 
 // Returns the unit vector of `a`. For vectors with a length less than a small
-// value `epsilon` a zero vector is returned.
+// value `epsilon` the original vector is returned.
 template <typename T>
 inline auto unit_vector(const Vec<T, 3> &a, const T& epsilon = DBL_EPSILON) -> Vec<decltype(a[0] / std::abs(a[0])), 3> {
   const double length = norm(a);
@@ -244,26 +280,33 @@ inline auto unit_vector(const Vec<T, 3> &a, const T& epsilon = DBL_EPSILON) -> V
   return a / length;
 }
 
+/// Returns the sum of the elements in the vector a
 template <typename T>
 inline constexpr T sum(const Vec<T,3>& a) {
   return a[0] + a[1] + a[2];
 }
 
+/// Returns the product of the elements in the vector a
 template <typename T>
 inline constexpr T product(const Vec<T,3>& a) {
   return a[0] * a[1] * a[2];
 }
 
+/// Returns a complex Vec3 with the conjugate of each component of a,
+/// x_k = conj(a_k)
 template <typename T>
 inline constexpr Vec<std::complex<T>,3> conj(const Vec<std::complex<T>,3>& a) {
   return {std::conj(a[0]), std::conj(a[1]), std::conj(a[2])};
 }
 
+/// Returns a complex Vec3 with each component of a truncated,
+/// x_k = trunc(a_k)
 template <typename T>
 inline constexpr Vec<T,3> trunc(const Vec<T,3>& a) {
   return {std::trunc(a[0]), std::trunc(a[1]), std::trunc(a[2])};
 }
 
+/// Returns a Vec3 of doubles static_casted from the vector a
 template <typename T>
 inline constexpr Vec<double,3> to_double(const Vec<T,3>& a) {
   return {
@@ -273,6 +316,7 @@ inline constexpr Vec<double,3> to_double(const Vec<T,3>& a) {
   };
 }
 
+/// Returns a Vec3 of ints static_casted from the vector a
 template <typename T>
 inline constexpr Vec<int,3> to_int(const Vec<T,3>& a) {
   return {
@@ -282,18 +326,21 @@ inline constexpr Vec<int,3> to_int(const Vec<T,3>& a) {
   };
 }
 
+/// Returns the largest absolute value in the array
 template <typename T, std::size_t N>
-T abs_max(const std::array<T,N>& x) {
+T absolute_max(const std::array<T,N>& x) {
   return std::abs(*std::max_element(x.begin(), x.end(),
                            [](const T& a, const T& b) {
                                return std::abs(a) < std::abs(b); }));
 }
 
+/// Returns a Vec with each component divided by its magnitude. Components
+/// of zero are left as zero. x_k = a_k / |a_k|
 template <typename T, std::size_t N>
-Vec<T, N> normalize_components(const Vec<T, N>& x) {
+Vec<T, N> normalize_components(const Vec<T, N>& a) {
   Vec<T, N> result;
   for (auto i = 0; i < N; ++i) {
-    x[i] != 0 ? result[i] = x[i]/abs(x[i]) : result[i] = 0;
+    a[i] != 0 ? result[i] = a[i]/abs(a[i]) : result[i] = 0;
   }
   return result;
 }

--- a/src/jams/core/interactions.cc
+++ b/src/jams/core/interactions.cc
@@ -522,7 +522,7 @@ write_interaction_data(ostream &output, const vector<InteractionData> &data, Coo
     output << setw(12) << interaction.unit_cell_pos_j << "\t";
     output << setw(12) << interaction.type_i << "\t";
     output << setw(12) << interaction.type_j << "\t";
-    output << setw(12) << fixed << abs(interaction.r_ij) << "\t";
+    output << setw(12) << fixed << norm(interaction.r_ij) << "\t";
     if (coord_format == CoordinateFormat::CARTESIAN) {
       output << setw(12) << fixed << interaction.r_ij[0] << "\t";
       output << setw(12) << fixed << interaction.r_ij[1] << "\t";

--- a/src/jams/cuda/cuda_device_vector_ops.h
+++ b/src/jams/cuda/cuda_device_vector_ops.h
@@ -17,11 +17,13 @@ __device__ inline double dot(const double3 &a, const double3 &b) {
   return a.x * b.x + a.y * b.y + a.z * b.z;
 }
 
-__device__ inline float abs(const float v1[3]) {
+/// Returns the square of the Euclidean norm (x^2 + y^2 + z^2) of the vector.
+__device__ inline float norm_squared(const float v1[3]) {
 	return dot(v1, v1);
 }
 
-__device__ inline double abs(const double v1[3]) {
+/// Returns the square of the Euclidean norm (x^2 + y^2 + z^2) of the vector.
+__device__ inline double norm_squared(const double v1[3]) {
 	return dot(v1, v1);
 }
 

--- a/src/jams/hamiltonian/cubic_anisotropy.cc
+++ b/src/jams/hamiltonian/cubic_anisotropy.cc
@@ -130,13 +130,18 @@ double CubicHamiltonian::calculate_energy(const int i) {
     Vec3 spin = {s(i, 0), s(i, 1), s(i, 2)};
 
     if(order_(i, n) == 1) {
-      energy += -magnitude_(i,n) * (dot_sq(axis1_(i,n), spin) * dot_sq(axis2_(i,n), spin)
-                                    + dot_sq(axis2_(i,n), spin) * dot_sq(axis3_(i,n), spin)
-                                    + dot_sq(axis3_(i,n), spin) * dot_sq(axis1_(i,n), spin) );
+      energy += -magnitude_(i,n) * (dot_squared(axis1_(i, n), spin) *
+                                    dot_squared(axis2_(i, n), spin)
+                                    + dot_squared(axis2_(i, n), spin) * dot_squared(
+          axis3_(i, n), spin)
+                                    + dot_squared(axis3_(i, n), spin) * dot_squared(
+          axis1_(i, n), spin) );
     }
 
     if(order_(i, n) == 2){
-      energy += -magnitude_(i,n) * ( dot_sq(axis1_(i,n), spin) * dot_sq(axis2_(i,n), spin) * dot_sq(axis3_(i,n), spin) );
+      energy += -magnitude_(i,n) * (dot_squared(axis1_(i, n), spin) *
+                                    dot_squared(axis2_(i, n), spin) *
+                                    dot_squared(axis3_(i, n), spin) );
     }
   }
 
@@ -151,18 +156,38 @@ double CubicHamiltonian::calculate_energy_difference(int i, const Vec3 &spin_ini
   for (auto n = 0; n < num_coefficients_; ++n) {
     if(order_(i, n) == 1) {
       e_initial += -magnitude_(i,n) * (
-          dot_sq(axis1_(i,n), spin_initial) * dot_sq(axis2_(i,n), spin_initial)
-          + dot_sq(axis2_(i,n), spin_initial) * dot_sq(axis3_(i,n), spin_initial)
-          + dot_sq(axis3_(i,n), spin_initial) * dot_sq(axis1_(i,n), spin_initial) );
+                                          dot_squared(axis1_(i, n),
+                                                      spin_initial) *
+                                          dot_squared(axis2_(i, n),
+                                                          spin_initial)
+                                          + dot_squared(axis2_(i, n), spin_initial) *
+            dot_squared(axis3_(i, n), spin_initial)
+          + dot_squared(axis3_(i, n), spin_initial) *
+            dot_squared(axis1_(i, n), spin_initial) );
 
-      e_final += -magnitude_(i,n) * (dot_sq(axis1_(i,n), spin_final) * dot_sq(axis2_(i,n), spin_final)
-                                     + dot_sq(axis2_(i,n), spin_final) * dot_sq(axis3_(i,n), spin_final)
-                                     + dot_sq(axis3_(i,n), spin_final) * dot_sq(axis1_(i,n), spin_final) );
+      e_final += -magnitude_(i,n) * (dot_squared(axis1_(i, n), spin_final) *
+                                     dot_squared(axis2_(i, n), spin_final)
+                                     + dot_squared(axis2_(i, n), spin_final) *
+                                       dot_squared(
+                                                                                    axis3_(
+                                                                                        i,
+                                                                                        n),
+                                                                                    spin_final)
+                                     + dot_squared(axis3_(i, n), spin_final) *
+                                       dot_squared(
+                                                                                                                           axis1_(
+                                                                                                                               i,
+                                                                                                                               n),
+                                                                                                                           spin_final) );
     }
 
     if(order_(i, n) == 2) {
-      e_initial += -magnitude_(i,n) * ( dot_sq(axis1_(i,n), spin_initial) * dot_sq(axis2_(i,n), spin_initial) * dot_sq(axis3_(i,n), spin_initial) );
-      e_final += -magnitude_(i,n) * ( dot_sq(axis1_(i,n), spin_final) * dot_sq(axis2_(i,n), spin_final) * dot_sq(axis3_(i,n), spin_final) );
+      e_initial += -magnitude_(i,n) * (dot_squared(axis1_(i, n), spin_initial) *
+                                       dot_squared(axis2_(i, n), spin_initial) *
+                                       dot_squared(axis3_(i, n), spin_initial) );
+      e_final += -magnitude_(i,n) * (dot_squared(axis1_(i, n), spin_final) *
+                                     dot_squared(axis2_(i, n), spin_final) *
+                                     dot_squared(axis3_(i, n), spin_final) );
     }
   }
 
@@ -186,18 +211,30 @@ Vec3 CubicHamiltonian::calculate_field(const int i) {
     if (order_(i, n) == 1) {
       for (auto j = 0; j < 3; ++j) {
         field[j] += pre * (
-            axis1_(i,n)[j] * dot(axis1_(i, n), spin) * (dot_sq(axis2_(i,n), spin) + dot_sq(axis3_(i,n), spin))
-            + axis2_(i,n)[j] * dot(axis2_(i, n), spin) * (dot_sq(axis3_(i,n), spin) + dot_sq(axis1_(i,n), spin))
-            + axis3_(i,n)[j] * dot(axis3_(i, n), spin) * (dot_sq(axis1_(i,n), spin) + dot_sq(axis2_(i,n), spin)) );
+            axis1_(i,n)[j] * dot(axis1_(i, n), spin) * (dot_squared(
+                axis2_(i, n), spin) +
+                                                        dot_squared(axis3_(i, n), spin))
+            + axis2_(i,n)[j] * dot(axis2_(i, n), spin) * (dot_squared(
+                axis3_(i, n), spin) +
+                                                          dot_squared(axis1_(i, n), spin))
+            + axis3_(i,n)[j] * dot(axis3_(i, n), spin) * (dot_squared(
+                axis1_(i, n), spin) +
+                                                          dot_squared(axis2_(i, n), spin)) );
       }
     }
 
     if (order_(i, n) == 2) {
       for (auto j = 0; j < 3; ++j) {
         field[j] += pre * (
-            axis1_(i,n)[j]  * dot(axis1_(i, n), spin) * (dot_sq(axis2_(i,n), spin) * dot_sq(axis3_(i,n), spin))
-            + axis2_(i,n)[j]  * dot(axis2_(i, n), spin) * (dot_sq(axis3_(i,n), spin) * dot_sq(axis1_(i,n), spin))
-            + axis3_(i,n)[j]  * dot(axis3_(i, n), spin) * (dot_sq(axis1_(i,n), spin) * dot_sq(axis2_(i,n), spin)) );
+            axis1_(i,n)[j]  * dot(axis1_(i, n), spin) * (dot_squared(
+                axis2_(i, n), spin) *
+                                                         dot_squared(axis3_(i, n), spin))
+            + axis2_(i,n)[j]  * dot(axis2_(i, n), spin) * (dot_squared(
+                axis3_(i, n), spin) *
+                                                           dot_squared(axis1_(i, n), spin))
+            + axis3_(i,n)[j]  * dot(axis3_(i, n), spin) * (dot_squared(
+                axis1_(i, n), spin) *
+                                                           dot_squared(axis2_(i, n), spin)) );
       }
     }
   }

--- a/src/jams/hamiltonian/cuda_dipole_bruteforce.cu
+++ b/src/jams/hamiltonian/cuda_dipole_bruteforce.cu
@@ -143,13 +143,16 @@ Vec3 CudaDipoleBruteforceHamiltonian::calculate_field(const int i) {
 
     Vec3 r_ij = displacement(i, j);
 
-    const auto r_abs_sq = norm_sq(r_ij);
+    const auto r_abs_sq = norm_squared(r_ij);
 
     if (definately_greater_than(r_abs_sq, r_cut_squared, jams::defaults::lattice_tolerance*jams::defaults::lattice_tolerance)) continue;
 
-    hx += w0 * mus(j) * (3.0 * r_ij[0] * dot(s_j, r_ij) - norm_sq(r_ij) * s_j[0]) / pow5(norm(r_ij));
-    hy += w0 * mus(j) * (3.0 * r_ij[1] * dot(s_j, r_ij) - norm_sq(r_ij) * s_j[1]) / pow5(norm(r_ij));;
-    hz += w0 * mus(j) * (3.0 * r_ij[2] * dot(s_j, r_ij) - norm_sq(r_ij) * s_j[2]) / pow5(norm(r_ij));;
+    hx += w0 * mus(j) * (3.0 * r_ij[0] * dot(s_j, r_ij) -
+        norm_squared(r_ij) * s_j[0]) / pow5(norm(r_ij));
+    hy += w0 * mus(j) * (3.0 * r_ij[1] * dot(s_j, r_ij) -
+        norm_squared(r_ij) * s_j[1]) / pow5(norm(r_ij));;
+    hz += w0 * mus(j) * (3.0 * r_ij[2] * dot(s_j, r_ij) -
+        norm_squared(r_ij) * s_j[2]) / pow5(norm(r_ij));;
   }
 
   return {hx, hy, hz};

--- a/src/jams/hamiltonian/cuda_dipole_fft.cu
+++ b/src/jams/hamiltonian/cuda_dipole_fft.cu
@@ -261,7 +261,7 @@ CudaDipoleFFTHamiltonian::generate_kspace_dipole_tensor(const int pos_i, const i
                                           lattice->generate_cartesian_lattice_position_from_fractional(r_frac_i,
                                                                                                        {nx, ny, nz})); // generate_cartesian_lattice_position_from_fractional requires FRACTIONAL coordinate
 
-                const auto r_abs_sq = norm_sq(r_ij);
+                const auto r_abs_sq = norm_squared(r_ij);
 
                 if (!std::isnormal(r_abs_sq)) {
                   throw runtime_error("fatal error in CudaDipoleFFTHamiltonian::generate_kspace_dipole_tensor: r_abs_sq is not normal");

--- a/src/jams/hamiltonian/dipole_bruteforce.cc
+++ b/src/jams/hamiltonian/dipole_bruteforce.cc
@@ -103,12 +103,15 @@ Vec3 DipoleBruteforceHamiltonian::calculate_field(const int i) {
 
     Vec3 r_ij = displacement(i, j);
 
-    const auto r_abs_sq = norm_sq(r_ij);
+    const auto r_abs_sq = norm_squared(r_ij);
 
     if (definately_greater_than(r_abs_sq, r_cut_squared, jams::defaults::lattice_tolerance)) continue;
-    hx += w0 * mus(j) * (3.0 * r_ij[0] * dot(s_j, r_ij) - norm_sq(r_ij) * s_j[0]) / pow5(norm(r_ij));
-    hy += w0 * mus(j) * (3.0 * r_ij[1] * dot(s_j, r_ij) - norm_sq(r_ij) * s_j[1]) / pow5(norm(r_ij));;
-    hz += w0 * mus(j) * (3.0 * r_ij[2] * dot(s_j, r_ij) - norm_sq(r_ij) * s_j[2]) / pow5(norm(r_ij));;
+    hx += w0 * mus(j) * (3.0 * r_ij[0] * dot(s_j, r_ij) -
+        norm_squared(r_ij) * s_j[0]) / pow5(norm(r_ij));
+    hy += w0 * mus(j) * (3.0 * r_ij[1] * dot(s_j, r_ij) -
+        norm_squared(r_ij) * s_j[1]) / pow5(norm(r_ij));;
+    hz += w0 * mus(j) * (3.0 * r_ij[2] * dot(s_j, r_ij) -
+        norm_squared(r_ij) * s_j[2]) / pow5(norm(r_ij));;
   }
 
   return {hx, hy, hz};

--- a/src/jams/hamiltonian/dipole_fft.cc
+++ b/src/jams/hamiltonian/dipole_fft.cc
@@ -242,7 +242,7 @@ DipoleFFTHamiltonian::generate_kspace_dipole_tensor(const int pos_i, const int p
                                                 lattice->generate_cartesian_lattice_position_from_fractional(r_frac_i,
                                                                                                              {nx, ny,
                                                                                                               nz}));
-        const auto r_abs_sq = norm_sq(r_ij);
+        const auto r_abs_sq = norm_squared(r_ij);
 
         if (r_abs_sq > pow2(r_cutoff_ + r_distance_tolerance_)) {
           continue;

--- a/src/jams/hamiltonian/dipole_neartree.cc
+++ b/src/jams/hamiltonian/dipole_neartree.cc
@@ -86,7 +86,8 @@ Vec3 DipoleNearTreeHamiltonian::calculate_field(const int i)
     const Vec3 s_j = {s(j,0), s(j,1), s(j,2)};
     const Vec3 r_ij =  neighbour.first - r_i;
 
-    field += w0 * mus(j) * (3.0 * r_ij * dot(s_j, r_ij) - norm_sq(r_ij) * s_j) / pow5(norm(r_ij));
+    field += w0 * mus(j) * (3.0 * r_ij * dot(s_j, r_ij) -
+        norm_squared(r_ij) * s_j) / pow5(norm(r_ij));
   }
   return field;
 }

--- a/src/jams/hamiltonian/dipole_neighbour_list.cc
+++ b/src/jams/hamiltonian/dipole_neighbour_list.cc
@@ -131,7 +131,8 @@ Vec3 DipoleNeighbourListHamiltonian::calculate_field(const int i)
     Vec3 s_j = {s(j,0), s(j,1), s(j,2)};
     Vec3 r_ij =  neighbour.first - r_i;
 
-    field += w0 * mus(j) * (3.0 * r_ij * dot(s_j, r_ij) - norm_sq(r_ij) * s_j) / pow5(norm(r_ij));
+    field += w0 * mus(j) * (3.0 * r_ij * dot(s_j, r_ij) -
+        norm_squared(r_ij) * s_j) / pow5(norm(r_ij));
   }
   return field;
 }

--- a/src/jams/lattice/minimum_image.cc
+++ b/src/jams/lattice/minimum_image.cc
@@ -85,7 +85,7 @@ Vec3 jams::minimum_image_bruteforce_explicit_depth(const Vec3 &a, const Vec3 &b,
         // offset cell
         auto r_ik = r_i - ((h * a + k * b + l * c) + r_j);
 
-        if (definately_less_than(norm_sq(r_ik), norm_sq(r_ij), epsilon)) {
+        if (definately_less_than(norm_squared(r_ik), norm_squared(r_ij), epsilon)) {
           r_ij = r_ik;
         }
       }

--- a/src/jams/monitors/spectrum_base.cc
+++ b/src/jams/monitors/spectrum_base.cc
@@ -81,17 +81,17 @@ void SpectrumBaseMonitor::configure_periodogram(libconfig::Setting &settings) {
 vector<HKLIndex> SpectrumBaseMonitor::generate_hkl_kspace_path(const vector<Vec3> &hkl_nodes, const Vec3i &kspace_size) {
   vector<HKLIndex> hkl_path;
   for (auto n = 0; n < hkl_nodes.size()-1; ++n) {
-    Vec3i origin = to_int(scale(hkl_nodes[n], kspace_size));
-    Vec3i displacement = to_int(scale(hkl_nodes[n+1], kspace_size)) - origin;
+    Vec3i origin = to_int(hadamard_product(hkl_nodes[n], kspace_size));
+    Vec3i displacement = to_int(hadamard_product(hkl_nodes[n + 1], kspace_size)) - origin;
     Vec3i delta = normalize_components(displacement);
 
     // use +1 to include the last point on the displacement
-    const auto num_coordinates = abs_max(displacement) + 1;
+    const auto num_coordinates = absolute_max(displacement) + 1;
 
     Vec3i coordinate = origin;
     for (auto i = 0; i < num_coordinates; ++i) {
       // map an arbitrary coordinate into the limited k indicies of the reduced brillouin zone
-      Vec3 hkl = scale(coordinate, 1.0/to_double(kspace_size));
+      Vec3 hkl = hadamard_product(coordinate, 1.0 / to_double(kspace_size));
       Vec3 xyz = lattice->get_unitcell().inv_fractional_to_cartesian(hkl);
       hkl_path.push_back(HKLIndex{hkl, xyz, fftw_r2c_index(coordinate, kspace_size)});
 

--- a/src/jams/monitors/spectrum_fourier.cc
+++ b/src/jams/monitors/spectrum_fourier.cc
@@ -106,7 +106,7 @@ SpectrumFourierMonitor::SpectrumFourierMonitor(const libconfig::Setting &setting
       cout << "cfg_vec: " << cfg_vec << "\n";
     }
 
-    cfg_vec = scale(cfg_vec, ::lattice->kspace_size());
+    cfg_vec = hadamard_product(cfg_vec, ::lattice->kspace_size());
 
     auto bz_vec = cfg_vec;
 

--- a/src/jams/monitors/spin_correlation.cc
+++ b/src/jams/monitors/spin_correlation.cc
@@ -86,7 +86,7 @@ void SpinCorrelationMonitor::post_process() {
           sum += sz_data_(i, t) * sz_data_(j, t);
         }
 
-        const auto r_ij_sq = norm_sq(r_ij);
+        const auto r_ij_sq = norm_squared(r_ij);
 
         if (do_in_plane) {
           in_plane_sz_corr_histogram_[r_ij_sq].count += num_samples_;

--- a/src/jams/monitors/spin_temperature.cc
+++ b/src/jams/monitors/spin_temperature.cc
@@ -32,7 +32,7 @@ void SpinTemperatureMonitor::update(Solver * solver) {
     const Vec3 spin = {s(i,0), s(i,1), s(i,2)};
     const Vec3 field = {h(i,0), h(i,1), h(i,2)};
 
-    sum_s_cross_h += norm_sq(cross(spin, field));
+    sum_s_cross_h += norm_squared(cross(spin, field));
     sum_s_dot_h += dot(spin, field);
   }
 

--- a/src/jams/test/containers/test_neartree.h
+++ b/src/jams/test/containers/test_neartree.h
@@ -30,7 +30,7 @@ TEST(NearTreeTest, L1Norm) {
     using NeartreeFunctorType = std::function<double(const Position& a, const Position& b)>;
 
     auto l1_norm = [](const Position& a, const Position& b)->double {
-      return sum(abs(a.first-b.first));
+      return sum(absolute(a.first-b.first));
     };
 
     NearTree<Position, NeartreeFunctorType> near_tree(l1_norm, positions);
@@ -48,7 +48,7 @@ TEST(NearTreeTest, L1Norm) {
         // We need to use the same floating point comparison here as we use within the near_tree
         // otherwise we can very occasionally fail the test on the basis of the difference between
         // using '<' and doing a proper floating point comparison.
-        if (!definately_greater_than(sum(abs( positions[i].first-positions[j].first)), radius, epsilon)) {
+        if (!definately_greater_than(sum(absolute( positions[i].first-positions[j].first)), radius, epsilon)) {
           brute_force_neighbours.push_back(positions[j]);
         }
       }


### PR DESCRIPTION
Some of the vector operations in cuda_device_vector_ops.h and for Vec types are poorly named to the point where some make no sense. For example abs is defined as ||a||^2 in cuda_device_vector_ops.h. All the uses for the functions seem to be correct, so likely a refactor has changed these in the past because they're not protected by namespaces.

I've now given several vector functions more verbose and clearer names as well as writing documentation for each function to be clear what is calculated.