### PR TITLE
Fix thermostat segfault

### DIFF
--- a/src/jams/core/thermostat.cc
+++ b/src/jams/core/thermostat.cc
@@ -14,7 +14,7 @@
 #include <stdexcept>
 #include <iostream>
 
-Thermostat* Thermostat::create(const std::string &thermostat_name) {
+Thermostat* Thermostat::create(const std::string &thermostat_name, const double timestep) {
   std::cout << thermostat_name << " thermostat\n";
 
   auto temperature = jams::config_required<double>(
@@ -23,16 +23,16 @@ Thermostat* Thermostat::create(const std::string &thermostat_name) {
   // create the selected thermostat
   #if HAS_CUDA
   if (capitalize(thermostat_name) == "LANGEVIN-WHITE-GPU" || capitalize(thermostat_name) == "CUDA_LANGEVIN_WHITE") {
-      return new CudaLangevinWhiteThermostat(temperature, 0.0, globals::num_spins);
+      return new CudaLangevinWhiteThermostat(temperature, 0.0, timestep, globals::num_spins);
   }
   if (capitalize(thermostat_name) == "LANGEVIN-BOSE-GPU" ||capitalize(thermostat_name) == "CUDA_LANGEVIN_COTH") {
-    return new CudaLangevinBoseThermostat(temperature, 0.0, globals::num_spins);
+    return new CudaLangevinBoseThermostat(temperature, 0.0, timestep, globals::num_spins);
   }
   if (capitalize(thermostat_name) == "LANGEVIN-BOSE-SRK4-GPU") {
-    return new jams::BoseEinsteinCudaSRK4Thermostat(temperature, 0.0, globals::num_spins);
+    return new jams::BoseEinsteinCudaSRK4Thermostat(temperature, 0.0, timestep, globals::num_spins);
   }
   if (capitalize(thermostat_name) == "LANGEVIN-LORENTZIAN-GPU" || capitalize(thermostat_name) == "LANGEVIN-ARBITRARY-GPU" ||capitalize(thermostat_name) == "CUDA_LANGEVIN_ARBITRARY") {
-    return new CudaLorentzianThermostat(temperature, 0.0, globals::num_spins);
+    return new CudaLorentzianThermostat(temperature, 0.0, timestep, globals::num_spins);
   }
   #endif
 

--- a/src/jams/core/thermostat.h
+++ b/src/jams/core/thermostat.h
@@ -9,7 +9,7 @@
 
 class Thermostat {
  public:
-  Thermostat(const double &temperature, const double &sigma, const int num_spins)
+  Thermostat(const double &temperature, const double &sigma, const double timestep, const int num_spins)
     : temperature_(temperature),
       sigma_(num_spins, 3),
       noise_(num_spins, 3)
@@ -22,7 +22,7 @@ class Thermostat {
   virtual void update() = 0;
 
   // factory
-  static Thermostat* create(const std::string &thermostat_name);
+  static Thermostat* create(const std::string &thermostat_name, const double timestep);
 
   // accessors
   double temperature() const { return temperature_; }

--- a/src/jams/solvers/cuda_ll_lorentzian_rk4.cu
+++ b/src/jams/solvers/cuda_ll_lorentzian_rk4.cu
@@ -65,7 +65,7 @@ void CUDALLLorentzianRK4Solver::initialize(const libconfig::Setting& settings)
   std::cout << "t_min (ps) " << t_min << " steps (" << min_steps_ << ")\n";
 
   std::string thermostat_name = jams::config_optional<std::string>(globals::config->lookup("solver"), "thermostat", jams::defaults::solver_gpu_thermostat);
-  register_thermostat(Thermostat::create(thermostat_name));
+  register_thermostat(Thermostat::create(thermostat_name, this->time_step()));
 
   std::cout << "  thermostat " << thermostat_name.c_str() << "\n";
 

--- a/src/jams/solvers/cuda_llg_heun.cu
+++ b/src/jams/solvers/cuda_llg_heun.cu
@@ -34,7 +34,7 @@ void CUDAHeunLLGSolver::initialize(const libconfig::Setting& settings)
   std::cout << "\nt_min (ps) " << t_min << " steps " << min_steps_ << "\n";
 
   std::string thermostat_name = jams::config_optional<std::string>(globals::config->lookup("solver"), "thermostat", jams::defaults::solver_gpu_thermostat);
-  register_thermostat(Thermostat::create(thermostat_name));
+  register_thermostat(Thermostat::create(thermostat_name, this->time_step()));
 
   std::cout << "  thermostat " << thermostat_name.c_str() << "\n";
 

--- a/src/jams/solvers/cuda_llg_rk4.cu
+++ b/src/jams/solvers/cuda_llg_rk4.cu
@@ -41,7 +41,7 @@ void CUDALLGRK4Solver::initialize(const libconfig::Setting& settings)
   std::cout << "t_min " << t_min << " steps (" << min_steps_ << ")\n";
 
   std::string thermostat_name = jams::config_optional<std::string>(globals::config->lookup("solver"), "thermostat", jams::defaults::solver_gpu_thermostat);
-  register_thermostat(Thermostat::create(thermostat_name));
+  register_thermostat(Thermostat::create(thermostat_name, this->time_step()));
 
   std::cout << "  thermostat " << thermostat_name.c_str() << "\n";
 

--- a/src/jams/thermostats/cuda_langevin_bose.cu
+++ b/src/jams/thermostats/cuda_langevin_bose.cu
@@ -27,8 +27,8 @@
 #include "jams/thermostats/cuda_langevin_bose.h"
 #include "jams/thermostats/cuda_langevin_bose_kernel.h"
 
-CudaLangevinBoseThermostat::CudaLangevinBoseThermostat(const double &temperature, const double &sigma, const int num_spins)
-: Thermostat(temperature, sigma, num_spins),
+CudaLangevinBoseThermostat::CudaLangevinBoseThermostat(const double &temperature, const double &sigma, const double timestep, const int num_spins)
+: Thermostat(temperature, sigma, timestep, num_spins),
   debug_(false)
   {
    std::cout << "\n  initialising CUDA Langevin semi-quantum noise thermostat\n";
@@ -41,7 +41,7 @@ CudaLangevinBoseThermostat::CudaLangevinBoseThermostat(const double &temperature
    omega_max_ = 25.0 * kTwoPi;
    globals::config->lookupValue("thermostat.w_max", omega_max_);
 
-   double dt_thermostat = double(::globals::config->lookup("solver.t_step")) / 1e-12;
+   double dt_thermostat = timestep;
    delta_tau_ = (dt_thermostat * kBoltzmannIU) / kHBarIU;
 
    std::cout << "    omega_max (THz) " << omega_max_ / (kTwoPi) << "\n";

--- a/src/jams/thermostats/cuda_langevin_bose.h
+++ b/src/jams/thermostats/cuda_langevin_bose.h
@@ -16,7 +16,7 @@
 
 class CudaLangevinBoseThermostat : public Thermostat {
  public:
-  CudaLangevinBoseThermostat(const double &temperature, const double &sigma, const int num_spins);
+  CudaLangevinBoseThermostat(const double &temperature, const double &sigma, const double timestep, const int num_spins);
   ~CudaLangevinBoseThermostat();
 
   void update();

--- a/src/jams/thermostats/cuda_langevin_white.cc
+++ b/src/jams/thermostats/cuda_langevin_white.cc
@@ -19,8 +19,8 @@
 
 #include "jams/monitors/magnetisation.h"
 
-CudaLangevinWhiteThermostat::CudaLangevinWhiteThermostat(const double &temperature, const double &sigma, const int num_spins)
-: Thermostat(temperature, sigma, num_spins),
+CudaLangevinWhiteThermostat::CudaLangevinWhiteThermostat(const double &temperature, const double &sigma, const double timestep, const int num_spins)
+: Thermostat(temperature, sigma, timestep, num_spins),
   dev_stream_(nullptr) {
   std::cout << "\n  initialising CUDA Langevin white noise thermostat\n";
 
@@ -38,7 +38,7 @@ CudaLangevinWhiteThermostat::CudaLangevinWhiteThermostat(const double &temperatu
         denominator = 1.0 + pow2(globals::alpha(i));
       }
       sigma_(i, j) = sqrt((2.0 * kBoltzmannIU * globals::alpha(i)) /
-                          (globals::mus(i) * globals::gyro(i) * globals::solver->time_step() * denominator));
+                          (globals::mus(i) * globals::gyro(i) * timestep * denominator));
     }
   }
   std::cout << "  done\n\n";

--- a/src/jams/thermostats/cuda_langevin_white.h
+++ b/src/jams/thermostats/cuda_langevin_white.h
@@ -11,7 +11,7 @@
 
 class CudaLangevinWhiteThermostat : public Thermostat {
  public:
-  CudaLangevinWhiteThermostat(const double &temperature, const double &sigma, const int num_spins);
+  CudaLangevinWhiteThermostat(const double &temperature, const double &sigma, const double timestep, const int num_spins);
 
   void update();
 

--- a/src/jams/thermostats/cuda_lorentzian.cu
+++ b/src/jams/thermostats/cuda_lorentzian.cu
@@ -30,8 +30,8 @@
 
 //#define PRINT_NOISE
 
-CudaLorentzianThermostat::CudaLorentzianThermostat(const double &temperature, const double &sigma, const int num_spins)
-: Thermostat(temperature, sigma, num_spins),
+CudaLorentzianThermostat::CudaLorentzianThermostat(const double &temperature, const double &sigma, const double timestep, const int num_spins)
+: Thermostat(temperature, sigma, timestep, num_spins),
   filter_temperature_(0.0) {
 
   std::cout << "\n  initialising CUDA Langevin arbitrary noise thermostat\n";
@@ -59,7 +59,7 @@ CudaLorentzianThermostat::CudaLorentzianThermostat(const double &temperature, co
       globals::config->lookup("thermostat"), "lorentzian_omega0");
 
 
-  delta_t_ = globals::solver->time_step();
+  delta_t_ = timestep;
   max_omega_ = kPi / delta_t_;
   delta_omega_ = max_omega_ / double(num_freq_);
 
@@ -94,7 +94,7 @@ CudaLorentzianThermostat::CudaLorentzianThermostat(const double &temperature, co
 
   for (int i = 0; i < num_spins; ++i) {
     for (int j = 0; j < 3; ++j) {
-      sigma_(i, j) = sqrt(1.0 / globals::solver->time_step());
+      sigma_(i, j) = sqrt(1.0 / timestep);
     }
   }
 

--- a/src/jams/thermostats/cuda_lorentzian.h
+++ b/src/jams/thermostats/cuda_lorentzian.h
@@ -134,7 +134,7 @@
 
 class CudaLorentzianThermostat : public Thermostat {
 public:
-    CudaLorentzianThermostat(const double &temperature, const double &sigma, const int num_spins);
+    CudaLorentzianThermostat(const double &temperature, const double &sigma, const double timestep, const int num_spins);
     ~CudaLorentzianThermostat();
 
     void update();

--- a/src/jams/thermostats/thm_bose_einstein_cuda_srk4.cu
+++ b/src/jams/thermostats/thm_bose_einstein_cuda_srk4.cu
@@ -16,8 +16,8 @@
 #include <string>
 #include <iostream>
 
-jams::BoseEinsteinCudaSRK4Thermostat::BoseEinsteinCudaSRK4Thermostat(const double &temperature, const double &sigma, const int num_spins)
-: Thermostat(temperature, sigma, num_spins) {
+jams::BoseEinsteinCudaSRK4Thermostat::BoseEinsteinCudaSRK4Thermostat(const double &temperature, const double &sigma, const double timestep, const int num_spins)
+: Thermostat(temperature, sigma, timestep, num_spins) {
    std::cout << "\n  initialising CUDA Langevin semi-quantum noise thermostat\n";
 
    jams_warning("This thermostat is currently broken. Do not use for production work.");
@@ -27,7 +27,7 @@ jams::BoseEinsteinCudaSRK4Thermostat::BoseEinsteinCudaSRK4Thermostat(const doubl
    warmup_time = warmup_time / 1e-12; // convert into ps
 
    const auto& solver_settings = globals::config->lookup("solver");
-   auto solver_time_step = jams::config_required<double>(solver_settings, "t_step") / 1e-12;  // convert into ps
+   auto solver_time_step = timestep;
 
    delta_tau_ = (solver_time_step * kBoltzmannIU) / kHBarIU;
    num_warm_up_steps_ = static_cast<unsigned>(warmup_time / solver_time_step);

--- a/src/jams/thermostats/thm_bose_einstein_cuda_srk4.h
+++ b/src/jams/thermostats/thm_bose_einstein_cuda_srk4.h
@@ -53,7 +53,7 @@ namespace jams {
 
 class BoseEinsteinCudaSRK4Thermostat : public Thermostat {
 public:
-    BoseEinsteinCudaSRK4Thermostat(const double &temperature, const double &sigma, const int num_spins);
+    BoseEinsteinCudaSRK4Thermostat(const double &temperature, const double &sigma, const double timestep, const int num_spins);
     ~BoseEinsteinCudaSRK4Thermostat() override = default;
 
     void update() override;


### PR DESCRIPTION
We create the thermostats inside the solver constructor, but the thermostats read the global solver instance (which is not yet constructed) to get the timestep. All the thermostats require a timestep, so I've refactors so the timestep is passed in as an argument to the factory.