### PR TITLE
Output magnetisation floats in scientific format

### DIFF
--- a/src/jams/monitors/magnetisation.cc
+++ b/src/jams/monitors/magnetisation.cc
@@ -71,10 +71,10 @@ void MagnetisationMonitor::update(Solver& solver) {
 
   tsv_file.width(12);
   tsv_file << fmt::sci << solver.time();
-  tsv_file << fmt::decimal << solver.physics()->temperature();
+  tsv_file << fmt::sci << solver.physics()->temperature();
 
   for (auto i = 0; i < 3; ++i) {
-    tsv_file << fmt::decimal << solver.physics()->applied_field(i);
+    tsv_file << fmt::sci << solver.physics()->applied_field(i);
   }
 
   for (auto n = 0; n < group_spin_indicies_.size(); ++n) {
@@ -86,10 +86,10 @@ void MagnetisationMonitor::update(Solver& solver) {
       // internally we use meV T^-1 for mus so convert back to Bohr magneton
       normalising_factor = 1.0 / kBohrMagnetonIU;
     }
-    tsv_file << fmt::decimal << mag[0] * normalising_factor;
-    tsv_file << fmt::decimal << mag[1] * normalising_factor;
-    tsv_file << fmt::decimal << mag[2] * normalising_factor;
-    tsv_file << fmt::decimal << norm(mag) * normalising_factor;
+    tsv_file << fmt::sci << mag[0] * normalising_factor;
+    tsv_file << fmt::sci << mag[1] * normalising_factor;
+    tsv_file << fmt::sci << mag[2] * normalising_factor;
+    tsv_file << fmt::sci << norm(mag) * normalising_factor;
   }
 
   tsv_file << std::endl;
@@ -102,10 +102,10 @@ std::string MagnetisationMonitor::tsv_header() {
   ss.width(12);
 
   ss << fmt::sci << "time";
-  ss << fmt::decimal << "T";
-  ss << fmt::decimal << "hx";
-  ss << fmt::decimal << "hy";
-  ss << fmt::decimal << "hz";
+  ss << fmt::sci << "T";
+  ss << fmt::sci << "hx";
+  ss << fmt::sci << "hy";
+  ss << fmt::sci << "hz";
 
   if (grouping_ == Grouping::MATERIALS) {
     for (auto i = 0; i < globals::lattice->num_materials(); ++i) {
@@ -119,7 +119,7 @@ std::string MagnetisationMonitor::tsv_header() {
       auto material_name = globals::lattice->material_name(
           globals::lattice->motif_atom(i).material_index);
       for (const auto &suffix: {"_mx", "_my", "_mz", "_m"}) {
-        ss << fmt::decimal << std::to_string(i+1) + "_" + material_name + suffix;
+        ss << fmt::sci << std::to_string(i+1) + "_" + material_name + suffix;
       }
     }
   }


### PR DESCRIPTION
When temperature is off and the oscillations are very small they are not visible within the significant figures of the fixed float format. Switching to scientific format allows more precision.