### PR TITLE
Fix lattice volume calculation

### DIFF
--- a/src/jams/core/lattice.cc
+++ b/src/jams/core/lattice.cc
@@ -106,9 +106,6 @@ double Lattice::parameter() const {
   return lattice_parameter;
 }
 
-double Lattice::volume() const {
-  return ::volume(supercell) * pow3(lattice_parameter);
-}
 
 int Lattice::size(int i) const {
   return lattice_dimensions[i];
@@ -381,7 +378,7 @@ void Lattice::read_unitcell_from_config(const libconfig::Setting &settings) {
 
   cout << "  unit cell\n";
   cout << "    parameter " << jams::fmt::sci << lattice_parameter << " (m)\n";
-  cout << "    volume " << jams::fmt::sci << this->volume() << " (m^3)\n";
+  cout << "    volume " << jams::fmt::sci << ::volume(unitcell) * pow3(lattice_parameter) << " (m^3)\n";
   cout << "\n";
 
   cout << "    unit cell vectors\n";
@@ -415,12 +412,13 @@ void Lattice::read_lattice_from_config(const libconfig::Setting &settings) {
   cout << "  lattice\n";
   cout << "    size " << lattice_dimensions << " (unit cells)\n";
   cout << "    periodic " << lattice_periodic << "\n";
+  cout << "    volume " << jams::fmt::sci << ::volume(supercell) * pow3(lattice_parameter) << "\n";
   cout << "\n";
 
   if(settings.exists("impurities")) {
     impurity_map_ = read_impurities_from_config(settings["impurities"]);
     impurity_seed_ = jams::config_optional<unsigned>(settings, "impurities_seed", jams::instance().random_generator()());
-    cout << "  impurity seed " << impurity_seed_ << "\n";
+    cout << jams::fmt::integer << "  impurity seed " << impurity_seed_ << "\n";
   }
 }
 
@@ -474,7 +472,9 @@ void Lattice::init_unit_cell(const libconfig::Setting &lattice_settings, const l
   cout << "  format " << cfg_coordinate_format_name << "\n";
 
   for (const Atom &atom: motif_) {
-    cout << "    " << atom.id << " " << materials_.name(atom.material_index) << " " << atom.position << "\n";
+    cout << "    " << jams::fmt::integer << atom.id << " ";
+    cout << materials_.name(atom.material_index) << " ";
+    cout << jams::fmt::decimal << atom.position << "\n";
   }
   cout << endl;
 

--- a/src/jams/core/lattice.h
+++ b/src/jams/core/lattice.h
@@ -44,7 +44,6 @@ public:
     Vec3i size() const;
 
     double parameter() const;   // [m]
-    double volume() const;      // [m^3]
 
     Vec3 a() const;
     Vec3 b() const;


### PR DESCRIPTION
Previously, the output file volume was incorrect. It was printed under the 'unitcell' heading, but the code indicatated it was the supercell volume, but the printing happens before the supercell is generated. So in the end it was always the volume of a cubic unit cell.

I've removed the volume() method from the lattice class to avoid any ambiguity about what this volume corresponds to. Now in the unit cell and lattice sections I output the correct volumes.