### PR TITLE
Fix exchange symmetry operations

### DIFF
--- a/src/jams/core/lattice.h
+++ b/src/jams/core/lattice.h
@@ -72,11 +72,11 @@ public:
     int atom_material_id(const int &i) const;           // integer index of the material
     std::string atom_material_name(const int &i) const; // name of the material of atom i
     const Vec3 & atom_position(const int &i) const;             // cartesian position in the supercell
-    const Vec3 & atom_fractional_position(const int &i) const;             // cartesian position in the supercell
+    const Vec3 & atom_fractional_position(const int &i) const;             // fractional position in the supercell
 
     const std::vector<Vec3>& atom_cartesian_positions() const;
 
-    unsigned atom_motif_position(const int &i) const;   // integer index within the motif
+    unsigned atom_motif_index(const int &i) const;   // integer index within the motif
     const std::vector<Mat3>& atom_motif_local_point_group_symops(const int &i); // return a vector of the point group operations local to the site
 
     int atom_unitcell(const int &i) const;
@@ -113,8 +113,8 @@ public:
 
     Vec3 generate_image_position(const Vec3 &unit_cell_cart_pos, const Vec3i &image_vector) const;
 
-    // Generates a list of points symmetric to r_cart based on the local point group symmetry of motif_position
-    std::vector<Vec3> generate_symmetric_points(const int motif_position, const Vec3 &r_cart, const double &tolerance);
+    // Generates a list of points symmetric to r_cart based on the local point group symmetry of motif_index
+    std::vector<Vec3> generate_symmetric_points(const int motif_index, const Vec3 &r_cart, const double &tolerance);
 
     Vec3 cartesian_to_fractional(const Vec3 &r_cart) const;
 
@@ -122,7 +122,7 @@ public:
 
     // Returns true if the points are a symmetry complete set (the symmetry operations on each point, generate
     // a point in the set), based on the local point group operations of the given motif position.
-    bool is_a_symmetry_complete_set(int motif_position, const std::vector<Vec3> &points, const double &tolerance);
+    bool is_a_symmetry_complete_set(int motif_index, const std::vector<Vec3> &points, const double &tolerance);
 
     // lookup the site index but unit cell integer coordinates and motif offset
     int site_index_by_unit_cell(const int &i, const int &j, const int &k, const int &m) const;

--- a/src/jams/core/types.h
+++ b/src/jams/core/types.h
@@ -52,7 +52,7 @@ struct Atom {
     int  id;
     int  material_index;
     int  motif_index;
-    Vec3 position;
+    Vec3 fractional_position;
 };
 
 template <typename T, typename Idx = int>

--- a/src/jams/hamiltonian/crystal_field.cc
+++ b/src/jams/hamiltonian/crystal_field.cc
@@ -68,7 +68,7 @@ CrystalFieldHamiltonian::CrystalFieldHamiltonian(const libconfig::Setting &setti
 
     for (auto i = 0; i < globals::num_spins; i++) {
       if (cf_params[0].isNumber()) {
-        if (globals::lattice->atom_motif_position(i) != int(cf_params[0]) - 1) {
+        if (globals::lattice->atom_motif_index(i) != int(cf_params[0]) - 1) {
           continue;
         }
       }

--- a/src/jams/hamiltonian/cuda_dipole_fft.cu
+++ b/src/jams/hamiltonian/cuda_dipole_fft.cu
@@ -225,8 +225,8 @@ jams::MultiArray<Complex, 4>
 CudaDipoleFFTHamiltonian::generate_kspace_dipole_tensor(const int pos_i, const int pos_j, std::vector<Vec3> &generated_positions) {
     using std::pow;
 
-    const Vec3 r_frac_i = globals::lattice->motif_atom(pos_i).position;
-    const Vec3 r_frac_j = globals::lattice->motif_atom(pos_j).position;
+    const Vec3 r_frac_i = globals::lattice->motif_atom(pos_i).fractional_position;
+    const Vec3 r_frac_j = globals::lattice->motif_atom(pos_j).fractional_position;
 
     const Vec3 r_cart_i = globals::lattice->fractional_to_cartesian(r_frac_i);
     const Vec3 r_cart_j = globals::lattice->fractional_to_cartesian(r_frac_j);

--- a/src/jams/hamiltonian/dipole_fft.cc
+++ b/src/jams/hamiltonian/dipole_fft.cc
@@ -198,8 +198,8 @@ Vec3 DipoleFFTHamiltonian::calculate_field(const int i, double time) {
 // the generated positions to a vector
 jams::MultiArray<Complex, 5>
 DipoleFFTHamiltonian::generate_kspace_dipole_tensor(const int pos_i, const int pos_j, std::vector<Vec3> &generated_positions) {
-  const Vec3 r_frac_i = globals::lattice->motif_atom(pos_i).position;
-  const Vec3 r_frac_j = globals::lattice->motif_atom(pos_j).position;
+  const Vec3 r_frac_i = globals::lattice->motif_atom(pos_i).fractional_position;
+  const Vec3 r_frac_j = globals::lattice->motif_atom(pos_j).fractional_position;
 
   const Vec3 r_cart_i = globals::lattice->fractional_to_cartesian(r_frac_i);
   const Vec3 r_cart_j = globals::lattice->fractional_to_cartesian(r_frac_j);

--- a/src/jams/hamiltonian/exchange_neartree.cc
+++ b/src/jams/hamiltonian/exchange_neartree.cc
@@ -47,7 +47,7 @@ ExchangeNeartreeHamiltonian::ExchangeNeartreeHamiltonian(const libconfig::Settin
     // check that no atoms in the unit cell are closer together than the distance_tolerance_
     for (auto i = 0; i < globals::lattice->num_motif_atoms(); ++i) {
       for (auto j = i+1; j < globals::lattice->num_motif_atoms(); ++j) {
-        const auto distance = norm(globals::lattice->motif_atom(i).position - globals::lattice->motif_atom(j).position);
+        const auto distance = norm(globals::lattice->motif_atom(i).fractional_position - globals::lattice->motif_atom(j).fractional_position);
         if(distance < distance_tolerance_) {
 
           throw jams::SanityException("Atoms ", i, " and ", j, " in the unit cell are close together (", distance,

--- a/src/jams/hamiltonian/uniaxial_anisotropy.cc
+++ b/src/jams/hamiltonian/uniaxial_anisotropy.cc
@@ -96,7 +96,7 @@ UniaxialAnisotropyHamiltonian::UniaxialAnisotropyHamiltonian(const Setting &sett
 
   for (const auto& ani : anisotropies) {
     for (auto i = 0; i < globals::num_spins; ++i) {
-      if (globals::lattice->atom_motif_position(i) == ani.motif_position) {
+      if (globals::lattice->atom_motif_index(i) == ani.motif_position) {
         magnitude_(i) = ani.energy * input_energy_unit_conversion_;
         for (auto j : {0, 1, 2}) {
           axis_(i, j) = ani.axis[j];

--- a/src/jams/helpers/interaction_calculator.cc
+++ b/src/jams/helpers/interaction_calculator.cc
@@ -32,7 +32,7 @@ namespace jams {
           for (auto k = -num_cells[2]; k < num_cells[2] + 1; ++k) {
             auto cell_offset = Vec3i{{i, j, k}};
             for (auto n = 0; n < motif.size(); ++n) {
-              auto r = motif[n].position + cell_offset;
+              auto r = motif[n].fractional_position + cell_offset;
               atoms.push_back({counter, motif[n].material_index, n, r});
               counter++;
             }
@@ -41,10 +41,10 @@ namespace jams {
       }
 
       for (auto n = 0; n < motif.size(); ++n) {
-        auto origin = motif[n].position;
+        auto origin = motif[n].fractional_position;
 
         auto cartesian_distance = [unitcell, origin](const Atom &a) -> double {
-            return norm(unitcell.matrix() * (a.position - origin));
+            return norm(unitcell.matrix() * (a.fractional_position - origin));
         };
 
         auto cartesian_distance_comp = [&](const Atom &a, const Atom &b) -> bool {
@@ -85,7 +85,7 @@ namespace jams {
 
           data.unit_cell_pos_i = n;
           data.unit_cell_pos_j = atom.motif_index;
-          data.r_ij = unitcell.matrix() * (atom.position - origin);
+          data.r_ij = unitcell.matrix() * (atom.fractional_position - origin);
           data.type_i = ::globals::lattice->material_name(motif[n].material_index);
           data.type_j = ::globals::lattice->material_name(atom.material_index);
 

--- a/src/jams/interface/fft.cc
+++ b/src/jams/interface/fft.cc
@@ -83,7 +83,7 @@ void apply_kspace_phase_factors(jams::MultiArray<std::complex<double>, 5> &kspac
   std::vector<complex<double>> exp_phase_z(globals::lattice->kspace_size()[2]);
 
   for (auto m = 0; m < globals::lattice->num_motif_atoms(); ++m) {
-    auto r_cart = globals::lattice->fractional_to_cartesian(globals::lattice->motif_atom(m).position);
+    auto r_cart = globals::lattice->fractional_to_cartesian(globals::lattice->motif_atom(m).fractional_position);
 
     precalculate_kspace_phase_factors(globals::lattice->kspace_size(), r_cart, exp_phase_x, exp_phase_y, exp_phase_z);
 

--- a/src/jams/monitors/magnetisation.cc
+++ b/src/jams/monitors/magnetisation.cc
@@ -55,7 +55,7 @@ MagnetisationMonitor::MagnetisationMonitor(const libconfig::Setting &settings)
   } else if (grouping_ == Grouping::POSITIONS) {
     std::vector<std::vector<int>> position_index_groups(globals::lattice->num_motif_atoms());
     for (auto i = 0; i < globals::num_spins; ++i) {
-      auto position = globals::lattice->atom_motif_position(i);
+      auto position = globals::lattice->atom_motif_index(i);
       position_index_groups[position].push_back(i);
     }
 

--- a/src/jams/monitors/magnon_spectrum.cc
+++ b/src/jams/monitors/magnon_spectrum.cc
@@ -184,7 +184,7 @@ MagnonSpectrumMonitor::calculate_magnon_spectrum(const jams::MultiArray<Vec3cx, 
 
   for (auto a = 0; a < num_sites; ++a) {
     // structure factor: note that q and r are in fractional coordinates (hkl, abc)
-    const Vec3 r = globals::lattice->motif_atom(a).position;
+    const Vec3 r = globals::lattice->motif_atom(a).fractional_position;
       for (auto k = 0; k < num_reciprocal_points; ++k) {
         auto kpoint = kspace_paths_[k];
         auto q = kpoint.hkl;

--- a/src/jams/monitors/neutron_scattering.cc
+++ b/src/jams/monitors/neutron_scattering.cc
@@ -103,7 +103,7 @@ jams::MultiArray<Complex, 2> NeutronScatteringMonitor::calculate_unpolarized_cro
 
   for (auto a = 0; a < num_sites; ++a) {
     for (auto b = 0; b < num_sites; ++b) {
-      Vec3 r_ab = globals::lattice->motif_atom(b).position - globals::lattice->motif_atom(a).position;
+      Vec3 r_ab = globals::lattice->motif_atom(b).fractional_position - globals::lattice->motif_atom(a).fractional_position;
 
       for (auto k = 0; k < num_reciprocal_points; ++k) {
         auto kpoint = kspace_paths_[k];
@@ -138,7 +138,7 @@ jams::MultiArray<Complex, 3> NeutronScatteringMonitor::calculate_polarized_cross
 
   for (auto a = 0; a < num_sites; ++a) {
     for (auto b = 0; b < num_sites; ++b) {
-      const Vec3 r_ab = globals::lattice->motif_atom(b).position - globals::lattice->motif_atom(a).position;
+      const Vec3 r_ab = globals::lattice->motif_atom(b).fractional_position - globals::lattice->motif_atom(a).fractional_position;
       for (auto k = 0; k < num_reciprocal_points; ++k) {
         auto kpoint = kspace_paths_[k];
         auto Q = unit_vector(kpoint.xyz);

--- a/src/jams/monitors/spin_correlation.cc
+++ b/src/jams/monitors/spin_correlation.cc
@@ -37,7 +37,7 @@ void SpinCorrelationMonitor::post_process() {
   std::vector<double> avg_sz(globals::lattice->num_motif_atoms(), 0.0);
 
   for (auto i = 0; i < globals::num_spins; ++i) {
-    auto n = globals::lattice->atom_motif_position(i);
+    auto n = globals::lattice->atom_motif_index(i);
     for (auto t = 0; t < num_samples_; ++t) {
       avg_sz[n] += sz_data_(i, t);
     }
@@ -49,7 +49,7 @@ void SpinCorrelationMonitor::post_process() {
 
   // subtract from the spin data
   for (auto i = 0; i < globals::num_spins; ++i) {
-    auto n = globals::lattice->atom_motif_position(i);
+    auto n = globals::lattice->atom_motif_index(i);
     for (auto t = 0; t < num_samples_; ++t) {
       sz_data_(i, t) -= avg_sz[n];
     }


### PR DESCRIPTION
After moving to using local symmetry operations on each site some exchange interactions were broken. There were two issues:

1) No symmetry operations were generated when specifying with materials because the unit cell index was -1 (interaction data was completed after symops)

2) After applying the rotations I was no translating back into the unit cell to identify if it was the same atom.