### PR TITLE
Fix std::exception inheritance

### DIFF
--- a/src/jams/helpers/exception.h
+++ b/src/jams/helpers/exception.h
@@ -8,7 +8,7 @@
 
 namespace jams {
 
-class GeneralException : std::exception {
+class GeneralException : public std::exception {
   std::string msg;
  public:
   template<class ... Args>


### PR DESCRIPTION
By default `std::exception` was inherited as private which then meant `GeneralException` and all derived classes could not be caught using `catch (const std::exception& ex)`