### PR TITLE
Rename thermostats to match naming conventions as discussed with Janet and co.

### DIFF
--- a/cmake/Sources.cmake
+++ b/cmake/Sources.cmake
@@ -133,6 +133,6 @@ set(JAMS_SOURCES_CUDA
         solvers/cuda_rk4_llg_sot.cu
         thermostats/thm_bose_einstein_cuda_srk4.cu
         thermostats/thm_bose_einstein_cuda_srk4_kernel.cuh
-        thermostats/cuda_langevin_bose.cu
-        thermostats/cuda_lorentzian.cu
+        thermostats/cuda_thermostat_quantum_spde.cu
+        thermostats/cuda_thermostat_general_fft.cu
         thermostats/cuda_langevin_white.cc)

--- a/src/jams/core/thermostat.cc
+++ b/src/jams/core/thermostat.cc
@@ -5,10 +5,10 @@
 #include "jams/core/globals.h"
 #include "jams/helpers/utils.h"
 
-#include "jams/thermostats/cuda_langevin_white.h"
+#include "jams/thermostats/cuda_thermostat_classical.h"
 #include "jams/thermostats/thm_bose_einstein_cuda_srk4.h"
-#include "jams/thermostats/cuda_lorentzian.h"
-#include "jams/thermostats/cuda_langevin_bose.h"
+#include "jams/thermostats/cuda_thermostat_general_fft.h"
+#include "jams/thermostats/cuda_thermostat_quantum_spde.h"
 
 #include <string>
 #include <stdexcept>
@@ -23,16 +23,16 @@ Thermostat* Thermostat::create(const std::string &thermostat_name, const double 
   // create the selected thermostat
   #if HAS_CUDA
   if (capitalize(thermostat_name) == "CLASSICAL-GPU" || capitalize(thermostat_name) == "LANGEVIN-WHITE-GPU" || capitalize(thermostat_name) == "CUDA_LANGEVIN_WHITE") {
-      return new CudaLangevinWhiteThermostat(temperature, 0.0, timestep, globals::num_spins);
+      return new CudaThermostatClassical(temperature, 0.0, timestep, globals::num_spins);
   }
   if (capitalize(thermostat_name) == "QUANTUM-SPDE-GPU" || capitalize(thermostat_name) == "LANGEVIN-BOSE-GPU" ||capitalize(thermostat_name) == "CUDA_LANGEVIN_COTH") {
-    return new CudaLangevinBoseThermostat(temperature, 0.0, timestep, globals::num_spins);
+    return new CudaThermostatQuantumSpde(temperature, 0.0, timestep, globals::num_spins);
   }
   if (capitalize(thermostat_name) == "LANGEVIN-BOSE-SRK4-GPU") {
     return new jams::BoseEinsteinCudaSRK4Thermostat(temperature, 0.0, timestep, globals::num_spins);
   }
   if (capitalize(thermostat_name) == "GENERAL-FFT-GPU" || capitalize(thermostat_name) == "LANGEVIN-LORENTZIAN-GPU" || capitalize(thermostat_name) == "LANGEVIN-ARBITRARY-GPU" ||capitalize(thermostat_name) == "CUDA_LANGEVIN_ARBITRARY") {
-    return new CudaLorentzianThermostat(temperature, 0.0, timestep, globals::num_spins);
+    return new CudaThermostatGeneralFFT(temperature, 0.0, timestep, globals::num_spins);
   }
   #endif
 

--- a/src/jams/core/thermostat.cc
+++ b/src/jams/core/thermostat.cc
@@ -22,16 +22,16 @@ Thermostat* Thermostat::create(const std::string &thermostat_name, const double 
 
   // create the selected thermostat
   #if HAS_CUDA
-  if (capitalize(thermostat_name) == "LANGEVIN-WHITE-GPU" || capitalize(thermostat_name) == "CUDA_LANGEVIN_WHITE") {
+  if (capitalize(thermostat_name) == "CLASSICAL-GPU" || capitalize(thermostat_name) == "LANGEVIN-WHITE-GPU" || capitalize(thermostat_name) == "CUDA_LANGEVIN_WHITE") {
       return new CudaLangevinWhiteThermostat(temperature, 0.0, timestep, globals::num_spins);
   }
-  if (capitalize(thermostat_name) == "LANGEVIN-BOSE-GPU" ||capitalize(thermostat_name) == "CUDA_LANGEVIN_COTH") {
+  if (capitalize(thermostat_name) == "QUANTUM-SPDE-GPU" || capitalize(thermostat_name) == "LANGEVIN-BOSE-GPU" ||capitalize(thermostat_name) == "CUDA_LANGEVIN_COTH") {
     return new CudaLangevinBoseThermostat(temperature, 0.0, timestep, globals::num_spins);
   }
   if (capitalize(thermostat_name) == "LANGEVIN-BOSE-SRK4-GPU") {
     return new jams::BoseEinsteinCudaSRK4Thermostat(temperature, 0.0, timestep, globals::num_spins);
   }
-  if (capitalize(thermostat_name) == "LANGEVIN-LORENTZIAN-GPU" || capitalize(thermostat_name) == "LANGEVIN-ARBITRARY-GPU" ||capitalize(thermostat_name) == "CUDA_LANGEVIN_ARBITRARY") {
+  if (capitalize(thermostat_name) == "GENERAL-FFT-GPU" || capitalize(thermostat_name) == "LANGEVIN-LORENTZIAN-GPU" || capitalize(thermostat_name) == "LANGEVIN-ARBITRARY-GPU" ||capitalize(thermostat_name) == "CUDA_LANGEVIN_ARBITRARY") {
     return new CudaLorentzianThermostat(temperature, 0.0, timestep, globals::num_spins);
   }
   #endif

--- a/src/jams/thermostats/cuda_thermostat_classical.cc
+++ b/src/jams/thermostats/cuda_thermostat_classical.cc
@@ -6,7 +6,7 @@
 #include <string>
 #include <iomanip>
 
-#include "cuda_langevin_white.h"
+#include "jams/thermostats/cuda_thermostat_classical.h"
 #include <jams/common.h>
 #include "jams/cuda/cuda_array_kernels.h"
 #include "jams/helpers/consts.h"
@@ -19,10 +19,10 @@
 
 #include "jams/monitors/magnetisation.h"
 
-CudaLangevinWhiteThermostat::CudaLangevinWhiteThermostat(const double &temperature, const double &sigma, const double timestep, const int num_spins)
+CudaThermostatClassical::CudaThermostatClassical(const double &temperature, const double &sigma, const double timestep, const int num_spins)
 : Thermostat(temperature, sigma, timestep, num_spins),
   dev_stream_(nullptr) {
-  std::cout << "\n  initialising CUDA Langevin white noise thermostat\n";
+  std::cout << "\n  initialising classical-gpu thermostat\n";
 
   cudaStreamCreate(&dev_stream_);
 
@@ -44,7 +44,7 @@ CudaLangevinWhiteThermostat::CudaLangevinWhiteThermostat(const double &temperatu
   std::cout << "  done\n\n";
 }
 
-void CudaLangevinWhiteThermostat::update() {
+void CudaThermostatClassical::update() {
   if (this->temperature() == 0) {
     CHECK_CUDA_STATUS(cudaMemset(noise_.device_data(), 0, noise_.elements()*sizeof(double)));
     return;

--- a/src/jams/thermostats/cuda_thermostat_classical.h
+++ b/src/jams/thermostats/cuda_thermostat_classical.h
@@ -1,7 +1,7 @@
 // Copyright 2014 Joseph Barker. All rights reserved.
 
-#ifndef JAMS_CUDA_THERMOSTAT_LANGEVIN_WHITE_H
-#define JAMS_CUDA_THERMOSTAT_LANGEVIN_WHITE_H
+#ifndef JAMS_CUDA_THERMOSTAT_CLASSICAL_H
+#define JAMS_CUDA_THERMOSTAT_CLASSICAL_H
 
 #if HAS_CUDA
 
@@ -9,9 +9,9 @@
 
 #include "jams/core/thermostat.h"
 
-class CudaLangevinWhiteThermostat : public Thermostat {
+class CudaThermostatClassical : public Thermostat {
  public:
-  CudaLangevinWhiteThermostat(const double &temperature, const double &sigma, const double timestep, const int num_spins);
+  CudaThermostatClassical(const double &temperature, const double &sigma, const double timestep, const int num_spins);
 
   void update();
 
@@ -28,4 +28,4 @@ class CudaLangevinWhiteThermostat : public Thermostat {
 };
 
 #endif  // CUDA
-#endif  // JAMS_CUDA_THERMOSTAT_LANGEVIN_WHITE_H
+#endif  // JAMS_CUDA_THERMOSTAT_CLASSICAL_H

--- a/src/jams/thermostats/cuda_thermostat_general_fft.h
+++ b/src/jams/thermostats/cuda_thermostat_general_fft.h
@@ -1,8 +1,8 @@
-#ifndef JAMS_CUDA_LORENTZIAN_THERMOSTAT_H
-#define JAMS_CUDA_LORENTZIAN_THERMOSTAT_H
+#ifndef JAMS_CUDA_THERMOSTAT_GENERAL_FFT_H
+#define JAMS_CUDA_THERMOSTAT_GENERAL_FFT_H
 
 /// ==============================
-/// Class CudaLorentzianThermostat
+/// Class CudaThermostatGeneralFFT
 /// ==============================
 /// Implements a thermostat based on harmonic oscillators with a Lorentzian
 /// coupling function following Anders, arXiv:2009.00600
@@ -132,10 +132,10 @@
 
 #include "jams/core/thermostat.h"
 
-class CudaLorentzianThermostat : public Thermostat {
+class CudaThermostatGeneralFFT : public Thermostat {
 public:
-    CudaLorentzianThermostat(const double &temperature, const double &sigma, const double timestep, const int num_spins);
-    ~CudaLorentzianThermostat();
+    CudaThermostatGeneralFFT(const double &temperature, const double &sigma, const double timestep, const int num_spins);
+    ~CudaThermostatGeneralFFT();
 
     void update();
 
@@ -143,6 +143,8 @@ public:
     const double* device_data() { return noise_.device_data(); }
 
 private:
+
+  void init_lorentzian(libconfig::Setting &settings, double eta_G);
 
   static double classical_spectrum(double omega, double temperature, double eta_G);
   static double no_zero_quantum_spectrum(double omega, double temperature, double eta_G);
@@ -207,7 +209,7 @@ private:
 // INLINE DEFINITIONS
 
 template<typename... Args>
-std::vector<double> CudaLorentzianThermostat::discrete_sqrt_psd(
+std::vector<double> CudaThermostatGeneralFFT::discrete_sqrt_psd(
     SpectralFunctionSignature<Args...> spectral_function,
     const double &delta_omega, const int &num_freq, Args &&... args) {
 
@@ -222,4 +224,4 @@ std::vector<double> CudaLorentzianThermostat::discrete_sqrt_psd(
 }
 
 #endif  // CUDA
-#endif  // JAMS_CUDA_LORENTZIAN_THERMOSTAT_H
+#endif  // JAMS_CUDA_THERMOSTAT_GENERAL_FFT_H

--- a/src/jams/thermostats/cuda_thermostat_general_fft_kernel.h
+++ b/src/jams/thermostats/cuda_thermostat_general_fft_kernel.h
@@ -1,5 +1,5 @@
-#ifndef JAMS_CUDA_THERMOSTAT_LANGEVIN_ARBITRARY_KERNEL_H
-#define JAMS_CUDA_THERMOSTAT_LANGEVIN_ARBITRARY_KERNEL_H
+#ifndef JAMS_CUDA_THERMOSTAT_GENERAL_FFT_KERNEL_H
+#define JAMS_CUDA_THERMOSTAT_GENERAL_FFT_KERNEL_H
 
 #include "jams/cuda/cuda_device_rk4.cuh"
 
@@ -10,7 +10,7 @@ __host__ __device__ inline int pbc(const int i, const int size) {
 // all threads should pull the same n-m at the same time, i.e.
 // a given n-m should be contiguous for all num_proc
 
-__global__ void arbitrary_stochastic_process_cuda_kernel
+__global__ void cuda_thermostat_general_fft_kernel
         (
                 double *noise_,
                 const double *filter,
@@ -34,4 +34,4 @@ __global__ void arbitrary_stochastic_process_cuda_kernel
   }
 }
 
-#endif  // JAMS_CUDA_THERMOSTAT_LANGEVIN_ARBITRARY_KERNEL_H
+#endif  // JAMS_CUDA_THERMOSTAT_GENERAL_FFT_KERNEL_H

--- a/src/jams/thermostats/cuda_thermostat_quantum_spde.h
+++ b/src/jams/thermostats/cuda_thermostat_quantum_spde.h
@@ -14,10 +14,10 @@
 
 #include "jams/core/thermostat.h"
 
-class CudaLangevinBoseThermostat : public Thermostat {
+class CudaThermostatQuantumSpde : public Thermostat {
  public:
-  CudaLangevinBoseThermostat(const double &temperature, const double &sigma, const double timestep, const int num_spins);
-  ~CudaLangevinBoseThermostat();
+  CudaThermostatQuantumSpde(const double &temperature, const double &sigma, const double timestep, const int num_spins);
+  ~CudaThermostatQuantumSpde();
 
   void update();
 

--- a/src/jams/thermostats/cuda_thermostat_quantum_spde_kernel.cuh
+++ b/src/jams/thermostats/cuda_thermostat_quantum_spde_kernel.cuh
@@ -73,7 +73,7 @@ rk4_vectored(void ode(const double[N], const double[N], const double[N], double[
   }
 }
 
-__global__ void bose_zero_point_stochastic_process_cuda_kernel
+__global__ void cuda_thermostat_quantum_spde_zero_point_kernel
         (
                 double *noise,
                 double *zeta,
@@ -127,7 +127,7 @@ __global__ void bose_zero_point_stochastic_process_cuda_kernel
 }
 
 
-__global__ void bose_coth_stochastic_process_cuda_kernel
+__global__ void cuda_thermostat_quantum_spde_no_zero_kernel
         (
                 double *noise,
                 double *zeta5,


### PR DESCRIPTION
classical ohmic noise (CO)
ohmic(ω)*T/ω

quantum ohmic noise (QO)
ohmic(ω)*coth(ω/T)

quantum no-zero ohmic noise (QNZO)
ohmic(ω)*[coth(ω/T) - 1]

classical lorentzian noise (CL)
lorentzian(ω)*T/ω

quantum lorentzian noise (QL)
lorentzian(ω)*coth(ω/T)

quantum no-zero lorentzian noise (QNZL)
lorentzian(ω)*[coth(ω/T) - 1]
