### PR TITLE
Add constrained MC constraint selection

### DIFF
--- a/docs/source/solvers/monte-carlo-constrained-cpu.rst
+++ b/docs/source/solvers/monte-carlo-constrained-cpu.rst
@@ -8,16 +8,25 @@ the order parameter to a given angle. The length of the order parameter is
 free to vary. Usually this solver is used in combination with the
 :ref:`torque monitor <torque-monitor>` to calculate free energy barriers.
 
-The constraint angles are applied to the order parameter vector
+The constraint angles can be applied to either the total magnetisation
 
 .. math::
-    \vec{N} = \sum_{i} \mu_{s,i} \left( \mathbb{T}_{i} \cdot \vec{S}_{i} \right)
+    \vec{M} = \sum_i \mu_{s,i} \vec{S}_i,
 
-where :math:`\mu_{s,i}` and :math:`\mathbb{T}_{i}` are the magnetic moment and
-the spin transform matrix of the :math:`i`-th spins as defined for each material
-(see :ref:`materials`). The transformation matrix allows Constrained Monte Carlo
-to be used for example with ferrimagnets and antiferrimagnets by use of the Neel
-vector rather than the magnetisation.
+or a material-transformed order parameter
+
+.. math::
+    \vec{N} = \sum_i \mu_{s,i} \left(\mathbb{T}_i \cdot \vec{S}_i\right).
+
+Here :math:`\mu_{s,i}` and :math:`\mathbb{T}_i` are the magnetic-moment
+magnitude and spin transform matrix of spin :math:`i`, as defined for its
+material (see :ref:`materials`). The sum includes every spin in the simulated
+supercell. Use the magnetisation constraint for a conventional ferro- or
+ferrimagnet when the direction of its physical total moment is required. Use
+the material-transformed constraint, for example, to flip one sublattice and
+constrain a Neel vector in an antiferromagnet or a transformed ferrimagnetic
+order parameter. The material-transformed definition is the default for
+backward compatibility.
 
 This Monte Carlo solver moves **two** spins for every trial. We define One Monte
 Carlo step as one trial move of every spin on average. Therefore `num_spins/2`
@@ -50,6 +59,24 @@ Azimuthal (in :math:`xy`-plane)  constraint angle in degrees.
 
 Optional settings
 ^^^^^^^^^^^^^^^^^
+
+.. describe:: cmc_constraint_type = "material_transform"
+
+Selects the collective vector whose direction is constrained. Valid values are
+``"magnetisation"`` for :math:`\vec{M}` and ``"material_transform"`` for
+:math:`\vec{N}`. Values are case-insensitive.
+
+For example, constrain the physical total magnetisation with
+
+.. code-block:: cfg
+
+    cmc_constraint_type = "magnetisation";
+
+or explicitly select the material transforms with
+
+.. code-block:: cfg
+
+    cmc_constraint_type = "material_transform";
 
 .. describe:: min_steps = 0
 

--- a/src/jams/solvers/cpu_monte_carlo_constrained.cc
+++ b/src/jams/solvers/cpu_monte_carlo_constrained.cc
@@ -9,6 +9,7 @@
 #include <jams/common.h>
 #include "jams/core/jams++.h"
 #include "jams/helpers/error.h"
+#include "jams/helpers/exception.h"
 #include "jams/helpers/utils.h"
 #include "jams/helpers/consts.h"
 #include "jams/helpers/maths.h"
@@ -30,6 +31,18 @@ namespace {
 
 void ConstrainedMCSolver::initialize(const libconfig::Setting& settings) {
   do_spin_initial_alignment_ = jams::config_optional(settings, "auto_align", do_spin_initial_alignment_);
+
+  const auto constraint_type_name = lowercase(jams::config_optional<std::string>(
+      settings, "cmc_constraint_type", "material_transform"));
+  if (constraint_type_name == "magnetisation") {
+    constraint_type_ = ConstraintType::Magnetisation;
+  } else if (constraint_type_name == "material_transform") {
+    constraint_type_ = ConstraintType::MaterialTransform;
+  } else {
+    throw jams::ConfigException(
+        settings["cmc_constraint_type"],
+        "must be either 'magnetisation' or 'material_transform'");
+  }
 
   max_steps_ = jams::config_required<int>(settings, "max_steps");
   min_steps_ = jams::config_optional<int>(settings, "min_steps", jams::defaults::solver_min_steps);
@@ -63,10 +76,12 @@ void ConstrainedMCSolver::initialize(const libconfig::Setting& settings) {
     move_fraction_reflection_  /= move_fraction_sum;
   }
 
-  spin_transformations_.resize(globals::num_spins);
+  constraint_transformations_.assign(globals::num_spins, kIdentityMat3);
   for (int i = 0; i < globals::num_spins; ++i) {
-    spin_transformations_[i] = globals::lattice->material(
-        globals::lattice->lattice_site_material_id(i)).transform;
+    if (constraint_type_ == ConstraintType::MaterialTransform) {
+      constraint_transformations_[i] = globals::lattice->material(
+          globals::lattice->lattice_site_material_id(i)).transform;
+    }
   }
 
   output_initialization_info(std::cout);
@@ -127,7 +142,7 @@ unsigned ConstrainedMCSolver::AsselinAlgorithm(const std::function<jams::Vec<dou
   std::uniform_real_distribution<> uniform_distribution;
 
   const double temperature = physics_module_->temperature();
-  jams::Vec<double, 3> magnetisation = total_transformed_magnetization();
+  jams::Vec<double, 3> order_parameter = total_constraint_vector();
 
   unsigned moves_accepted = 0;
 
@@ -168,16 +183,18 @@ unsigned ConstrainedMCSolver::AsselinAlgorithm(const std::function<jams::Vec<dou
 
     jams::Vec<double, 3> s2_trial = rotate_constraint_to_cartesian(s2, s2_trial_rotated);
 
-    jams::Vec<double, 3> delta_m = magnetization_difference(s1, s1_initial, s1_trial, s2, s2_initial, s2_trial);
+    jams::Vec<double, 3> delta_order_parameter = constraint_vector_difference(
+        s1, s1_initial, s1_trial, s2, s2_initial, s2_trial);
 
-    jams::Vec<double, 3> m_trial_rotated = rotation_matrix_ * (magnetisation + delta_m);
+    jams::Vec<double, 3> trial_order_parameter_rotated =
+        rotation_matrix_ * (order_parameter + delta_order_parameter);
 
-    if (m_trial_rotated[2] < 0.0) {
-      // The new magnetization is in the opposite sense - revert s1, reject move
+    if (trial_order_parameter_rotated[2] < 0.0) {
+      // The new order parameter is in the opposite sense - reject the move.
       continue;
     }
 
-    jams::Vec<double, 3> m_initial_rotated = rotation_matrix_ * (magnetisation);
+    jams::Vec<double, 3> initial_order_parameter_rotated = rotation_matrix_ * order_parameter;
 
     // calculate the Boltzmann weighted probability including the Jacobian factors (see paper)
     double delta_e = energy_difference(s1, s1_initial, s1_trial, s2, s2_initial, s2_trial);
@@ -189,7 +206,8 @@ unsigned ConstrainedMCSolver::AsselinAlgorithm(const std::function<jams::Vec<dou
       }
     } else {
       const double beta = 1.0 / (temperature * kBoltzmannIU);
-      double jacobian_factor = pow2(m_trial_rotated[2] / m_initial_rotated[2]) * abs(s2_initial_rotated[2] / s2_trial_rotated[2]);
+      double jacobian_factor = pow2(trial_order_parameter_rotated[2] / initial_order_parameter_rotated[2])
+          * abs(s2_initial_rotated[2] / s2_trial_rotated[2]);
       double probability = std::min(1.0, exp(-delta_e * beta) * jacobian_factor);
 
       if (uniform_distribution(jams::instance().random_generator()) > probability) {
@@ -202,7 +220,7 @@ unsigned ConstrainedMCSolver::AsselinAlgorithm(const std::function<jams::Vec<dou
     jams::montecarlo::set_spin(s1, s1_trial);
     jams::montecarlo::set_spin(s2, s2_trial);
 
-    magnetisation += delta_m;
+    order_parameter += delta_order_parameter;
 
     moves_accepted++;
   }
@@ -229,32 +247,50 @@ double ConstrainedMCSolver::energy_difference(const int &s1, const jams::Vec<dou
   return delta_energy1 + delta_energy2;
 }
 
-jams::Vec<double, 3> ConstrainedMCSolver::magnetization_difference(const int &s1, const jams::Vec<double, 3> &s1_initial, const jams::Vec<double, 3> &s1_trial,
+jams::Vec<double, 3> ConstrainedMCSolver::constraint_vector_difference(const int &s1, const jams::Vec<double, 3> &s1_initial, const jams::Vec<double, 3> &s1_trial,
                                                    const int &s2, const jams::Vec<double, 3> &s2_initial, const jams::Vec<double, 3> &s2_trial) const {
-  return globals::mus(s1) * (spin_transformations_[s1] * (s1_trial - s1_initial))
-  + globals::mus(s2) * (spin_transformations_[s2] * (s2_trial - s2_initial));
+  return globals::mus(s1) * spin_to_order_parameter(s1, s1_trial - s1_initial)
+      + globals::mus(s2) * spin_to_order_parameter(s2, s2_trial - s2_initial);
 }
 
-jams::Vec<double, 3> ConstrainedMCSolver::total_transformed_magnetization() const {
-  jams::Vec<double, 3> m_total = {0.0, 0.0, 0.0};
+jams::Vec<double, 3> ConstrainedMCSolver::total_constraint_vector() const {
+  jams::Vec<double, 3> total = {0.0, 0.0, 0.0};
 
   for (auto i = 0; i < globals::num_spins; ++i) {
-    m_total += globals::mus(i) * (spin_transformations_[i] *
-        jams::montecarlo::get_spin(i));
+    total += globals::mus(i) * spin_to_order_parameter(i, jams::montecarlo::get_spin(i));
   }
 
-  return m_total;
+  return total;
+}
+
+jams::Vec<double, 3> ConstrainedMCSolver::spin_to_order_parameter(const int &i, const jams::Vec<double, 3> &spin) const {
+  return constraint_transformations_[i] * spin;
+}
+
+jams::Vec<double, 3> ConstrainedMCSolver::order_parameter_to_spin(const int &i, const jams::Vec<double, 3> &spin) const {
+  return transpose(constraint_transformations_[i]) * spin;
 }
 
 jams::Vec<double, 3> ConstrainedMCSolver::rotate_cartesian_to_constraint(const int &i, const jams::Vec<double, 3> &spin) const {
-  return rotation_matrix_ * (spin_transformations_[i] * spin);
+  return rotation_matrix_ * spin_to_order_parameter(i, spin);
 }
 
 jams::Vec<double, 3> ConstrainedMCSolver::rotate_constraint_to_cartesian(const int &i, const jams::Vec<double, 3> &spin) const {
-  return transpose(spin_transformations_[i]) * (inverse_rotation_matrix_ * spin);
+  return order_parameter_to_spin(i, inverse_rotation_matrix_ * spin);
+}
+
+const char* ConstrainedMCSolver::constraint_type_name() const {
+  switch (constraint_type_) {
+    case ConstraintType::Magnetisation:
+      return "magnetisation";
+    case ConstraintType::MaterialTransform:
+      return "material_transform";
+  }
+  return "unknown";
 }
 
 void ConstrainedMCSolver::output_initialization_info(std::ostream &os) {
+  os << "    constraint type " << constraint_type_name() << "\n";
   os << "    constraint angle theta (deg) " << constraint_theta_ << "\n";
   os << "    constraint angle phi (deg) " << constraint_phi_ << "\n";
   os << "    constraint vector " << constraint_vector_[0] << " " << constraint_vector_[1] << " " << constraint_vector_[2] << "\n";
@@ -321,14 +357,14 @@ void ConstrainedMCSolver::output_running_stats_info(std::ostream &os) {
 
 
 void ConstrainedMCSolver::validate_constraint() const {
-  jams::Vec<double, 3> m_total = total_transformed_magnetization();
+  jams::Vec<double, 3> order_parameter = total_constraint_vector();
 
-  const double actual_theta = rad_to_deg(jams::polar_angle(m_total));
-  const double actual_phi = rad_to_deg(jams::azimuthal_angle(m_total));
+  const double actual_theta = rad_to_deg(jams::polar_angle(order_parameter));
+  const double actual_phi = rad_to_deg(jams::azimuthal_angle(order_parameter));
 
   if (!approximately_equal(actual_theta, constraint_theta_, jams::defaults::solver_monte_carlo_constraint_tolerance)) {
     std::stringstream ss;
-    ss << "ConstrainedMCSolver -- theta constraint (" << jams::fmt::decimal << constraint_theta_ << ") violated (" << std::setprecision(10) << std::setw(12) << rad_to_deg(jams::polar_angle(m_total)) << " deg)";
+    ss << "ConstrainedMCSolver -- theta constraint (" << jams::fmt::decimal << constraint_theta_ << ") violated (" << std::setprecision(10) << std::setw(12) << actual_theta << " deg)";
     throw std::runtime_error(ss.str());
   }
 
@@ -385,14 +421,16 @@ void ConstrainedMCSolver::sum_running_acceptance_statistics() {
 }
 
 void ConstrainedMCSolver::align_spins_to_constraint() const {
-  auto M = total_transformed_magnetization();
+  const auto order_parameter = total_constraint_vector();
 
-  auto rotation = rotation_matrix_between_vectors(M, constraint_vector_);
+  const auto rotation = rotation_matrix_between_vectors(order_parameter, constraint_vector_);
 
   for (auto i = 0; i < globals::num_spins; ++i) {
-    jams::Vec<double, 3> snew = rotation * jams::montecarlo::get_spin(i);
+    const auto spin = jams::montecarlo::get_spin(i);
+    const auto aligned_order_parameter_spin = rotation * spin_to_order_parameter(i, spin);
+    const auto aligned_spin = order_parameter_to_spin(i, aligned_order_parameter_spin);
     for (auto j : {0, 1, 2}) {
-      globals::s(i, j) = snew[j];
+      globals::s(i, j) = aligned_spin[j];
     }
   }
 }

--- a/src/jams/solvers/cpu_monte_carlo_constrained.h
+++ b/src/jams/solvers/cpu_monte_carlo_constrained.h
@@ -29,8 +29,15 @@ class ConstrainedMCSolver : public Solver {
   std::string name() const override { return "monte-carlo-constrained-cpu"; }
 
  private:
+    enum class ConstraintType {
+      Magnetisation,
+      MaterialTransform
+    };
+
     void output_initialization_info(std::ostream &os);
     void output_running_stats_info(std::ostream &os);
+
+    const char* constraint_type_name() const;
 
     void validate_angles() const;
     void validate_rotation_matricies() const;
@@ -44,14 +51,18 @@ class ConstrainedMCSolver : public Solver {
 
     unsigned AsselinAlgorithm(const std::function<jams::Vec<double, 3>(jams::Vec<double, 3>)>&  trial_spin_move);
 
+    jams::Vec<double, 3>     spin_to_order_parameter(const int &i, const jams::Vec<double, 3> &spin) const;
+    jams::Vec<double, 3>     order_parameter_to_spin(const int &i, const jams::Vec<double, 3> &spin) const;
     jams::Vec<double, 3>     rotate_cartesian_to_constraint(const int &i, const jams::Vec<double, 3> &spin) const;
     jams::Vec<double, 3>     rotate_constraint_to_cartesian(const int &i, const jams::Vec<double, 3> &spin) const;
-    jams::Vec<double, 3>     total_transformed_magnetization() const;
+    jams::Vec<double, 3>     total_constraint_vector() const;
 
     double   energy_difference(const int &s1, const jams::Vec<double, 3> &s1_initial, const jams::Vec<double, 3> &s1_trial, const int &s2, const jams::Vec<double, 3> &s2_initial, const jams::Vec<double, 3> &s2_trial) const;
-    jams::Vec<double, 3>     magnetization_difference(const int &s1, const jams::Vec<double, 3> &s1_initial, const jams::Vec<double, 3> &s1_trial, const int &s2, const jams::Vec<double, 3> &s2_initial, const jams::Vec<double, 3> &s2_trial) const;
+    jams::Vec<double, 3>     constraint_vector_difference(const int &s1, const jams::Vec<double, 3> &s1_initial, const jams::Vec<double, 3> &s1_trial, const int &s2, const jams::Vec<double, 3> &s2_initial, const jams::Vec<double, 3> &s2_trial) const;
 
     bool do_spin_initial_alignment_ = true;
+
+    ConstraintType constraint_type_ = ConstraintType::MaterialTransform;
 
     double constraint_theta_   = 0.0;
     double constraint_phi_     = 0.0;
@@ -60,7 +71,7 @@ class ConstrainedMCSolver : public Solver {
     jams::Mat<double, 3, 3> rotation_matrix_         = kIdentityMat3;
     jams::Mat<double, 3, 3> inverse_rotation_matrix_ = kIdentityMat3;
 
-    std::vector<jams::Mat<double, 3, 3>> spin_transformations_;
+    std::vector<jams::Mat<double, 3, 3>> constraint_transformations_;
 
     int output_write_steps_ = 100;
 

--- a/src/jams/test/jams_test.cc
+++ b/src/jams/test/jams_test.cc
@@ -23,6 +23,7 @@
 #include "jams/test/hamiltonian/test_anisotropy_polynomial.h"
 #include "jams/test/hamiltonian/test_dipole.h"
 #include "jams/test/hamiltonian/test_exchange_stencil.h"
+#include "jams/test/solvers/test_cpu_monte_carlo_constrained.h"
 #include "jams/test/solvers/test_cpu_rotations.h"
 #include "jams/test/thermostats/test_quantum_spde_noise.h"
 

--- a/src/jams/test/solvers/test_cpu_monte_carlo_constrained.h
+++ b/src/jams/test/solvers/test_cpu_monte_carlo_constrained.h
@@ -1,0 +1,247 @@
+#ifndef JAMS_TEST_SOLVERS_TEST_CPU_MONTE_CARLO_CONSTRAINED_H
+#define JAMS_TEST_SOLVERS_TEST_CPU_MONTE_CARLO_CONSTRAINED_H
+
+#include <cmath>
+#include <iomanip>
+#include <memory>
+#include <sstream>
+#include <string>
+
+#include <libconfig.h++>
+
+#include "gtest/gtest.h"
+
+#include "jams/common.h"
+#include "jams/core/globals.h"
+#include "jams/core/lattice.h"
+#include "jams/core/physics.h"
+#include "jams/helpers/exception.h"
+#include "jams/helpers/montecarlo.h"
+#include "jams/helpers/utils.h"
+#include "jams/solvers/cpu_monte_carlo_constrained.h"
+#include "jams/test/output.h"
+
+namespace {
+
+constexpr double kConstrainedMCTestTolerance = 1.0e-8;
+
+void reset_constrained_mc_globals() {
+  globals::solver = nullptr;
+  globals::num_spins = 0;
+  globals::num_spins3 = 0;
+  globals::num_magnetic_spins = 0;
+  jams::util::force_deallocation(globals::s);
+  jams::util::force_deallocation(globals::h);
+  jams::util::force_deallocation(globals::ds_dt);
+  jams::util::force_deallocation(globals::positions);
+  jams::util::force_deallocation(globals::alpha);
+  jams::util::force_deallocation(globals::mus);
+  jams::util::force_deallocation(globals::inv_mus);
+  jams::util::force_deallocation(globals::gyro);
+  globals::config = nullptr;
+  if (globals::lattice) {
+    delete globals::lattice;
+    globals::lattice = nullptr;
+  }
+}
+
+std::string constrained_mc_config(
+    const std::string& constraint_type,
+    const double theta,
+    const double phi,
+    const bool auto_align) {
+  std::ostringstream config;
+  config << std::fixed << std::setprecision(15);
+  config << R"(
+    solver = {
+      module = "monte-carlo-constrained-cpu";
+      max_steps = 100;
+      output_write_steps = 1;
+      move_angle_sigma = 0.05;
+      auto_align = )" << (auto_align ? "true" : "false") << ";\n";
+  if (!constraint_type.empty()) {
+    config << "      cmc_constraint_type = \"" << constraint_type << "\";\n";
+  }
+  config << "      cmc_constraint_theta = " << theta << ";\n"
+         << "      cmc_constraint_phi = " << phi << ";\n"
+         << R"(    };
+
+    physics = {
+      module = "empty";
+      temperature = 1000000.0;
+    };
+
+    materials = (
+      {
+        name = "A";
+        moment = 2.0;
+        spin = [1.0, 0.0, 0.0];
+        transform = ([1.0, 0.0, 0.0],
+                     [0.0, 1.0, 0.0],
+                     [0.0, 0.0, 1.0]);
+      },
+      {
+        name = "B";
+        moment = 1.0;
+        spin = [0.0, 1.0, 0.0];
+        transform = ([0.0, -1.0, 0.0],
+                     [1.0,  0.0, 0.0],
+                     [0.0,  0.0, 1.0]);
+      }
+    );
+
+    unitcell = {
+      symops = false;
+      parameter = 1e-10;
+      basis = (
+        [1.0, 0.0, 0.0],
+        [0.0, 1.0, 0.0],
+        [0.0, 0.0, 1.0]);
+      positions = (
+        ("A", [0.0, 0.0, 0.0]),
+        ("B", [0.5, 0.0, 0.0])
+      );
+    };
+
+    lattice = {
+      size = [1, 1, 1];
+      periodic = [true, true, true];
+    };
+  )";
+  return config.str();
+}
+
+jams::Vec<double, 3> constrained_mc_total(const bool apply_material_transform) {
+  jams::Vec<double, 3> total = {0.0, 0.0, 0.0};
+  for (auto i = 0; i < globals::num_spins; ++i) {
+    auto spin = jams::montecarlo::get_spin(i);
+    if (apply_material_transform) {
+      spin = globals::lattice->material(
+          globals::lattice->lattice_site_material_id(i)).transform * spin;
+    }
+    total += globals::mus(i) * spin;
+  }
+  return total;
+}
+
+void expect_direction(
+    const jams::Vec<double, 3>& vector,
+    const jams::Vec<double, 3>& expected) {
+  const auto direction = jams::normalize(vector);
+  for (auto component = 0; component < 3; ++component) {
+    EXPECT_NEAR(direction[component], expected[component], kConstrainedMCTestTolerance);
+  }
+}
+
+void expect_unit_spins() {
+  for (auto i = 0; i < globals::num_spins; ++i) {
+    EXPECT_NEAR(jams::norm(jams::montecarlo::get_spin(i)), 1.0, kConstrainedMCTestTolerance);
+  }
+}
+
+}  // namespace
+
+class ConstrainedMCSolverConstraintTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    reset_constrained_mc_globals();
+    jams::testing::toggle_cout();
+  }
+
+  void TearDown() override {
+    reset_constrained_mc_globals();
+    jams::testing::toggle_cout();
+  }
+
+  std::unique_ptr<ConstrainedMCSolver> make_solver(
+      const std::string& constraint_type,
+      const double theta,
+      const double phi,
+      const bool auto_align) {
+    globals::config = std::make_unique<libconfig::Config>();
+    const auto config_text = constrained_mc_config(constraint_type, theta, phi, auto_align);
+    globals::config->readString(config_text.c_str());
+    globals::lattice = new Lattice();
+    globals::lattice->init_from_config(*globals::config);
+    return std::make_unique<ConstrainedMCSolver>(globals::config->lookup("solver"));
+  }
+
+  void exercise_pair_moves(const std::string& constraint_type, const bool transformed) {
+    constexpr double theta = 55.0;
+    constexpr double phi = -35.0;
+    auto solver = make_solver(constraint_type, theta, phi, true);
+    solver->register_physics_module(Physics::create(globals::config->lookup("physics")));
+
+    const auto initial_spin_0 = jams::montecarlo::get_spin(0);
+    const auto initial_spin_1 = jams::montecarlo::get_spin(1);
+    jams::instance().random_generator().seed(13579u);
+
+    for (auto step = 0; step < 64; ++step) {
+      ASSERT_NO_THROW(solver->run());
+    }
+
+    const auto expected = jams::spherical_to_cartesian_vector(
+        1.0, deg_to_rad(theta), deg_to_rad(phi));
+    expect_direction(constrained_mc_total(transformed), expected);
+    expect_unit_spins();
+
+    const auto final_spin_0 = jams::montecarlo::get_spin(0);
+    const auto final_spin_1 = jams::montecarlo::get_spin(1);
+    const double total_change = jams::norm(final_spin_0 - initial_spin_0)
+        + jams::norm(final_spin_1 - initial_spin_1);
+    EXPECT_GT(total_change, 1.0e-6);
+  }
+};
+
+TEST_F(ConstrainedMCSolverConstraintTest, DefaultsToMaterialTransform) {
+  EXPECT_NO_THROW(make_solver("", 90.0, 0.0, false));
+  expect_direction(constrained_mc_total(true), {1.0, 0.0, 0.0});
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, MaterialTransformTypeIsCaseInsensitive) {
+  EXPECT_NO_THROW(make_solver("MaTeRiAl_TrAnSfOrM", 90.0, 0.0, false));
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, MagnetisationUsesMomentWeightedUntransformedSpins) {
+  const auto phi = rad_to_deg(std::atan2(1.0, 2.0));
+  EXPECT_NO_THROW(make_solver("MaGnEtIsAtIoN", 90.0, phi, false));
+  expect_direction(
+      constrained_mc_total(false),
+      {2.0 / std::sqrt(5.0), 1.0 / std::sqrt(5.0), 0.0});
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, ModesRejectTheOtherCollectiveVectorDirection) {
+  const auto magnetisation_phi = rad_to_deg(std::atan2(1.0, 2.0));
+  EXPECT_THROW(make_solver("magnetisation", 90.0, 0.0, false), std::runtime_error);
+
+  reset_constrained_mc_globals();
+  EXPECT_THROW(
+      make_solver("material_transform", 90.0, magnetisation_phi, false),
+      std::runtime_error);
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, RejectsUnknownConstraintType) {
+  EXPECT_THROW(make_solver("sublattice", 90.0, 0.0, false), jams::ConfigException);
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, MaterialTransformAlignmentOccursInOrderParameterSpace) {
+  auto solver = make_solver("material_transform", 0.0, 0.0, true);
+  expect_direction(constrained_mc_total(true), {0.0, 0.0, 1.0});
+  expect_unit_spins();
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, MagnetisationAlignmentIgnoresMaterialTransforms) {
+  auto solver = make_solver("magnetisation", 0.0, 0.0, true);
+  expect_direction(constrained_mc_total(false), {0.0, 0.0, 1.0});
+  expect_unit_spins();
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, PairMovesPreserveMagnetisationConstraint) {
+  exercise_pair_moves("magnetisation", false);
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, PairMovesPreserveMaterialTransformConstraint) {
+  exercise_pair_moves("material_transform", true);
+}
+
+#endif  // JAMS_TEST_SOLVERS_TEST_CPU_MONTE_CARLO_CONSTRAINED_H


### PR DESCRIPTION
Currently the constraint uses the transform in the materials setting. However, there may be cases when we simply want the total magnetisation as the constraint, but the transform setting might be being used for other purposes. Here we add a config setting so that the plain magnetisation can be constrained.