### PR TITLE
Make constrained MC tolerance configurable

### DIFF
--- a/docs/source/solvers/monte-carlo-constrained-cpu.rst
+++ b/docs/source/solvers/monte-carlo-constrained-cpu.rst
@@ -78,6 +78,18 @@ or explicitly select the material transforms with
 
     cmc_constraint_type = "material_transform";
 
+.. describe:: cmc_constraint_tolerance = 1e-6
+
+Maximum permitted angular separation, in degrees, between the requested
+constraint direction and the measured collective-vector direction during the
+solver's periodic constraint validation. The value must be finite and satisfy
+``0 < cmc_constraint_tolerance <= 180``.
+
+This setting controls only the threshold at which validation stops the solver;
+it does not alter or relax the constrained Monte Carlo trial moves themselves.
+The geometric direction comparison is independent of the azimuthal branch cut
+and remains well-defined at the polar directions.
+
 .. describe:: min_steps = 0
 
 Minimum number of Monte Carlo steps to solve (in case a monitor can stop

--- a/src/jams/helpers/defaults.h
+++ b/src/jams/helpers/defaults.h
@@ -31,6 +31,7 @@ namespace jams {
         constexpr int    solver_min_steps = 0;
         constexpr double solver_monte_carlo_move_sigma = 0.5;
         constexpr double solver_monte_carlo_constraint_tolerance = 1e-8;
+        constexpr double solver_monte_carlo_constraint_angular_tolerance_degrees = 1e-6;
         constexpr auto   solver_gpu_thermostat = "langevin-white-gpu";
 
         constexpr double material_gyro = 1.0;

--- a/src/jams/solvers/cpu_monte_carlo_constrained.cc
+++ b/src/jams/solvers/cpu_monte_carlo_constrained.cc
@@ -1,8 +1,8 @@
 // Copyright 2014 Joseph Barker. All rights reserved.
+#include <cmath>
 #include <iomanip>
 
 #include <libconfig.h++>
-#include "jams/helpers/output.h"
 
 #include "cpu_monte_carlo_constrained.h"
 
@@ -52,6 +52,18 @@ void ConstrainedMCSolver::initialize(const libconfig::Setting& settings) {
   // phi is angle in the x-y plane from 0 to 360
   constraint_phi_ = jams::config_required<double>(settings, "cmc_constraint_phi");
   constraint_phi_ = remap_azimuthal_angle_degrees(constraint_phi_);
+
+  constraint_tolerance_degrees_ = jams::config_optional<double>(
+      settings,
+      "cmc_constraint_tolerance",
+      jams::defaults::solver_monte_carlo_constraint_angular_tolerance_degrees);
+  if (!std::isfinite(constraint_tolerance_degrees_)
+      || constraint_tolerance_degrees_ <= 0.0
+      || constraint_tolerance_degrees_ > 180.0) {
+    throw jams::ConfigException(
+        settings["cmc_constraint_tolerance"],
+        "must be finite and in the range 0 < cmc_constraint_tolerance <= 180 degrees");
+  }
 
   move_angle_sigma_        = jams::config_optional<double>(settings, "move_angle_sigma", jams::defaults::solver_monte_carlo_move_sigma);
   output_write_steps_      = jams::config_optional<int>(settings, "output_write_steps",  jams::defaults::monitor_output_steps);
@@ -293,6 +305,7 @@ void ConstrainedMCSolver::output_initialization_info(std::ostream &os) {
   os << "    constraint type " << constraint_type_name() << "\n";
   os << "    constraint angle theta (deg) " << constraint_theta_ << "\n";
   os << "    constraint angle phi (deg) " << constraint_phi_ << "\n";
+  os << "    constraint angular tolerance (deg) " << constraint_tolerance_degrees_ << "\n";
   os << "    constraint vector " << constraint_vector_[0] << " " << constraint_vector_[1] << " " << constraint_vector_[2] << "\n";
   os << "    move_fraction_uniform " << move_fraction_uniform_ << "\n";
   os << "    move_fraction_angle " << move_fraction_angle_ << "\n";
@@ -357,38 +370,50 @@ void ConstrainedMCSolver::output_running_stats_info(std::ostream &os) {
 
 
 void ConstrainedMCSolver::validate_constraint() const {
-  jams::Vec<double, 3> order_parameter = total_constraint_vector();
+  const auto order_parameter = total_constraint_vector();
+  const double order_parameter_norm = jams::norm(order_parameter);
 
-  const double actual_theta = rad_to_deg(jams::polar_angle(order_parameter));
-  const double actual_phi = rad_to_deg(jams::azimuthal_angle(order_parameter));
-
-  if (!approximately_equal(actual_theta, constraint_theta_, jams::defaults::solver_monte_carlo_constraint_tolerance)) {
+  if (!std::isfinite(order_parameter[0])
+      || !std::isfinite(order_parameter[1])
+      || !std::isfinite(order_parameter[2])
+      || !std::isfinite(order_parameter_norm)
+      || order_parameter_norm == 0.0) {
     std::stringstream ss;
-    ss << "ConstrainedMCSolver -- theta constraint (" << jams::fmt::decimal << constraint_theta_ << ") violated (" << std::setprecision(10) << std::setw(12) << actual_theta << " deg)";
+    ss << "ConstrainedMCSolver -- constraint direction is undefined because the total constraint vector is zero or non-finite ("
+       << std::scientific << std::setprecision(12)
+       << order_parameter[0] << ", " << order_parameter[1] << ", " << order_parameter[2] << ")";
     throw std::runtime_error(ss.str());
   }
 
-  // theta is ~0 or 180 (i.e. it is at a pole) then the phi angle is undefined
-  const bool at_pole = approximately_zero(constraint_theta_, DBL_EPSILON) || approximately_equal(constraint_theta_, 180.0, DBL_EPSILON);
-  if (!at_pole) {
-    if (!approximately_equal_periodic(actual_phi, constraint_phi_, 360.0, jams::defaults::solver_monte_carlo_constraint_tolerance)) {
-      const double phi_error = std::remainder(actual_phi - constraint_phi_, 360.0);
-      std::stringstream ss;
-      ss << "ConstrainedMCSolver -- phi constraint (" << jams::fmt::decimal << constraint_phi_ << ") violated ("
-         << std::setprecision(10) << std::setw(12) << actual_phi << " deg; shortest angular difference "
-         << phi_error << " deg)";
-      throw std::runtime_error(ss.str());
-    }
+  const double angular_error_degrees = rad_to_deg(std::atan2(
+      jams::norm(jams::cross(order_parameter, constraint_vector_)),
+      jams::dot(order_parameter, constraint_vector_)));
+  if (!std::isfinite(angular_error_degrees)) {
+    throw std::runtime_error(
+        "ConstrainedMCSolver -- constraint direction is undefined because its angular difference is non-finite");
+  }
+
+  if (angular_error_degrees > constraint_tolerance_degrees_) {
+    const double actual_theta = rad_to_deg(jams::polar_angle(order_parameter));
+    const double actual_phi = rad_to_deg(jams::azimuthal_angle(order_parameter));
+    std::stringstream ss;
+    ss << "ConstrainedMCSolver -- constraint direction violated (requested theta "
+       << std::fixed << std::setprecision(10) << constraint_theta_ << " deg, phi "
+       << constraint_phi_ << " deg; actual theta " << actual_theta << " deg, phi "
+       << actual_phi << " deg; angular difference "
+       << std::scientific << std::setprecision(12) << angular_error_degrees
+       << " deg exceeds tolerance " << constraint_tolerance_degrees_ << " deg)";
+    throw std::runtime_error(ss.str());
   }
 }
 
 void ConstrainedMCSolver::validate_angles() const {
-  if (constraint_theta_ < 0 || constraint_theta_ > 180.0) {
+  if (!std::isfinite(constraint_theta_) || constraint_theta_ < 0 || constraint_theta_ > 180.0) {
     throw std::runtime_error(
         "ConstrainedMCSolver -- theta ( " + std::to_string(constraint_theta_) + " ) is out of range (0 <= theta <= 180)");
   }
 
-  if ( constraint_phi_ <= -180.0 || constraint_phi_ > 180.0) {
+  if (!std::isfinite(constraint_phi_) || constraint_phi_ <= -180.0 || constraint_phi_ > 180.0) {
     throw std::runtime_error(
         "ConstrainedMCSolver -- phi ( " + std::to_string(constraint_phi_) + " ) is out of range (-180 <= phi <= 180)");
   }

--- a/src/jams/solvers/cpu_monte_carlo_constrained.h
+++ b/src/jams/solvers/cpu_monte_carlo_constrained.h
@@ -8,6 +8,7 @@
 
 #include <jams/core/types.h>
 #include "jams/core/solver.h"
+#include "jams/helpers/defaults.h"
 #include "jams/helpers/montecarlo.h"
 
 #include "pcg_random.hpp"
@@ -66,6 +67,8 @@ class ConstrainedMCSolver : public Solver {
 
     double constraint_theta_   = 0.0;
     double constraint_phi_     = 0.0;
+    double constraint_tolerance_degrees_ =
+        jams::defaults::solver_monte_carlo_constraint_angular_tolerance_degrees;
     jams::Vec<double, 3>   constraint_vector_  = {{0.0, 0.0, 1.0}};
 
     jams::Mat<double, 3, 3> rotation_matrix_         = kIdentityMat3;

--- a/src/jams/test/solvers/test_cpu_monte_carlo_constrained.h
+++ b/src/jams/test/solvers/test_cpu_monte_carlo_constrained.h
@@ -2,8 +2,11 @@
 #define JAMS_TEST_SOLVERS_TEST_CPU_MONTE_CARLO_CONSTRAINED_H
 
 #include <cmath>
+#include <functional>
 #include <iomanip>
+#include <limits>
 #include <memory>
+#include <optional>
 #include <sstream>
 #include <string>
 
@@ -157,12 +160,21 @@ class ConstrainedMCSolverConstraintTest : public ::testing::Test {
       const std::string& constraint_type,
       const double theta,
       const double phi,
-      const bool auto_align) {
+      const bool auto_align,
+      const std::optional<double> constraint_tolerance = std::nullopt,
+      const std::function<void()>& prepare_spins = {}) {
     globals::config = std::make_unique<libconfig::Config>();
     const auto config_text = constrained_mc_config(constraint_type, theta, phi, auto_align);
     globals::config->readString(config_text.c_str());
+    if (constraint_tolerance.has_value()) {
+      globals::config->lookup("solver")
+          .add("cmc_constraint_tolerance", libconfig::Setting::TypeFloat) = *constraint_tolerance;
+    }
     globals::lattice = new Lattice();
     globals::lattice->init_from_config(*globals::config);
+    if (prepare_spins) {
+      prepare_spins();
+    }
     return std::make_unique<ConstrainedMCSolver>(globals::config->lookup("solver"));
   }
 
@@ -222,6 +234,104 @@ TEST_F(ConstrainedMCSolverConstraintTest, ModesRejectTheOtherCollectiveVectorDir
 
 TEST_F(ConstrainedMCSolverConstraintTest, RejectsUnknownConstraintType) {
   EXPECT_THROW(make_solver("sublattice", 90.0, 0.0, false), jams::ConfigException);
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, DefaultToleranceAcceptsRoundoffScaleDirectionalErrors) {
+  for (const auto angular_error_degrees : {1.2e-8, 5.0e-7}) {
+    SCOPED_TRACE(angular_error_degrees);
+    reset_constrained_mc_globals();
+    EXPECT_NO_THROW(make_solver(
+        "material_transform", 90.0, angular_error_degrees, false));
+  }
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, DefaultToleranceRejectsLargerDirectionalError) {
+  try {
+    auto solver = make_solver("material_transform", 90.0, 2.0e-6, false);
+    FAIL() << "expected constraint validation to fail";
+  } catch (const std::runtime_error& error) {
+    const std::string message = error.what();
+    EXPECT_NE(message.find("angular difference"), std::string::npos);
+    EXPECT_NE(message.find("exceeds tolerance"), std::string::npos);
+  }
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, ConfiguredLooseToleranceAcceptsLargerDirectionalError) {
+  EXPECT_NO_THROW(make_solver(
+      "material_transform", 90.0, 5.0e-5, false, 1.0e-4));
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, ConfiguredStrictToleranceRejectsSmallDirectionalError) {
+  EXPECT_THROW(
+      make_solver("material_transform", 90.0, 5.0e-7, false, 1.0e-8),
+      std::runtime_error);
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, RejectsInvalidConstraintTolerances) {
+  const double infinity = std::numeric_limits<double>::infinity();
+  const double nan = std::numeric_limits<double>::quiet_NaN();
+  for (const auto invalid_tolerance : {0.0, -1.0, 180.000001, infinity, nan}) {
+    SCOPED_TRACE(invalid_tolerance);
+    reset_constrained_mc_globals();
+    EXPECT_THROW(
+        make_solver("material_transform", 90.0, 0.0, false, invalid_tolerance),
+        jams::ConfigException);
+  }
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, AcceptsEquivalentDirectionAtAzimuthBranchCut) {
+  auto solver = make_solver("material_transform", 90.0, -180.0, true);
+  expect_direction(constrained_mc_total(true), {-1.0, 0.0, 0.0});
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, PolarDirectionDoesNotDependOnAzimuth) {
+  auto solver = make_solver("material_transform", 0.0, 123.0, true);
+  expect_direction(constrained_mc_total(true), {0.0, 0.0, 1.0});
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, RejectsZeroLengthConstraintVector) {
+  const auto make_transformed_total_zero = [] {
+    globals::mus(0) = 1.0;
+    globals::inv_mus(0) = 1.0;
+    globals::mus(1) = 1.0;
+    globals::inv_mus(1) = 1.0;
+  };
+
+  try {
+    auto solver = make_solver(
+        "material_transform",
+        90.0,
+        0.0,
+        false,
+        std::nullopt,
+        make_transformed_total_zero);
+    FAIL() << "expected an undefined constraint direction";
+  } catch (const std::runtime_error& error) {
+    EXPECT_NE(
+        std::string(error.what()).find("constraint direction is undefined"),
+        std::string::npos);
+  }
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, RejectsNonFiniteConstraintVector) {
+  const auto make_total_non_finite = [] {
+    globals::s(0, 0) = std::numeric_limits<double>::infinity();
+  };
+
+  try {
+    auto solver = make_solver(
+        "material_transform",
+        90.0,
+        0.0,
+        false,
+        std::nullopt,
+        make_total_non_finite);
+    FAIL() << "expected an undefined constraint direction";
+  } catch (const std::runtime_error& error) {
+    EXPECT_NE(
+        std::string(error.what()).find("constraint direction is undefined"),
+        std::string::npos);
+  }
 }
 
 TEST_F(ConstrainedMCSolverConstraintTest, MaterialTransformAlignmentOccursInOrderParameterSpace) {


### PR DESCRIPTION
Replace separate theta and phi comparisons with a coordinate-independent angular error computed from the collective constraint vector. Handle branch cuts and polar directions geometrically, and reject zero or non-finite collective vectors with explicit diagnostics.

Add the optional cmc_constraint_tolerance setting in degrees with a 1e-6 default and finite range validation. Keep the existing 1e-8 matrix sanity tolerance independent, print the selected tolerance during initialization, and document that it affects validation rather than Monte Carlo moves.

Add regression coverage for roundoff-scale residuals, strict and loose overrides, invalid settings, branch-cut equivalence, polar directions, and undefined vectors.