### PR TITLE
Generalise constrained Monte Carlo for spin spirals

### DIFF
--- a/docs/source/solvers/monte-carlo-constrained-cpu.rst
+++ b/docs/source/solvers/monte-carlo-constrained-cpu.rst
@@ -8,7 +8,7 @@ the order parameter to a given angle. The length of the order parameter is
 free to vary. Usually this solver is used in combination with the
 :ref:`torque monitor <torque-monitor>` to calculate free energy barriers.
 
-The constraint angles can be applied to either the total magnetisation
+The constrained collective vector can be either the total magnetisation
 
 .. math::
     \vec{M} = \sum_i \mu_{s,i} \vec{S}_i,
@@ -28,13 +28,52 @@ constrain a Neel vector in an antiferromagnet or a transformed ferrimagnetic
 order parameter. The material-transformed definition is the default for
 backward compatibility.
 
+Two spatial constraint modes are available. The default ``"global"`` mode
+uses the sums above over every spin in the simulated supercell. The
+``"spin_spiral"`` mode instead partitions the supercell into unit-cell planes
+normal to one reciprocal-lattice direction. For each plane :math:`p`, it
+constrains either
+
+.. math::
+    \vec{M}_p = \sum_{i\in p} \mu_{s,i}\vec{S}_i
+
+or
+
+.. math::
+    \vec{N}_p = \sum_{i\in p} \mu_{s,i}
+    \left(\mathbb{T}_i\cdot\vec{S}_i\right).
+
+The magnitude of every constrained vector remains free. Individual unit-cell
+vectors within a plane are not constrained and may fluctuate away from the
+plane direction.
+
+For an axis-aligned reciprocal wavevector with nonzero component :math:`q_d`,
+the target direction of the plane at integer unit-cell coordinate :math:`n_d`
+is
+
+.. math::
+    \hat{\vec{c}}_{n_d} =
+    R_{\hat{\vec{a}}}\!\left(2\pi q_d n_d\right)\hat{\vec{c}}_0,
+
+where :math:`\hat{\vec{a}}` is the Cartesian spin-rotation axis and
+
+.. math::
+    \hat{\vec{c}}_0 =
+    (\sin\theta\cos\phi,\sin\theta\sin\phi,\cos\theta).
+
+The wavevector is specified in cycles per unit cell, so the factor
+:math:`2\pi` is applied by the solver. Planes are grouped by their integer
+unit-cell coordinate, not merely by target direction: planes separated by a
+full turn remain independent constraints.
+
 This Monte Carlo solver moves **two** spins for every trial. We define One Monte
 Carlo step as one trial move of every spin on average. Therefore `num_spins/2`
 trial moves of pairs of spins are made for each Monte Carlo step.
 
-Trial spins are always chosen at random, both for the initial and second
-(compensation) spin in the pair. No consideration is given for whether the
-second spin is from the same material or unit cell position.
+In global mode both trial spins are selected globally as before. In
+spin-spiral mode the first spin is selected globally and the second
+(compensation) spin is selected uniformly from the other nonzero-moment spins
+in the same plane. It may belong to any unit cell or material in that plane.
 
 .. note::
     The solver will periodically check the constraint is being correctly maintained.
@@ -60,6 +99,12 @@ Azimuthal (in :math:`xy`-plane)  constraint angle in degrees.
 Optional settings
 ^^^^^^^^^^^^^^^^^
 
+.. describe:: cmc_constraint_mode = "global"
+
+Selects the spatial collective vectors whose directions are constrained.
+Valid, case-insensitive values are ``"global"`` for one supercell-wide vector
+and ``"spin_spiral"`` for one vector per unit-cell plane.
+
 .. describe:: cmc_constraint_type = "material_transform"
 
 Selects the collective vector whose direction is constrained. Valid values are
@@ -77,6 +122,43 @@ or explicitly select the material transforms with
 .. code-block:: cfg
 
     cmc_constraint_type = "material_transform";
+
+.. describe:: cmc_spiral_wavevector
+
+Required only when ``cmc_constraint_mode = "spin_spiral"``. A three-component
+reciprocal-lattice vector in cycles per unit cell. Exactly one component must
+be finite and nonzero; oblique and zero wavevectors are rejected.
+
+If propagation direction :math:`d` is periodic and contains :math:`L_d` unit
+cells, the spiral must satisfy
+
+.. math::
+    q_d L_d \in \mathbb{Z}.
+
+The numerical distance from :math:`q_dL_d` to the nearest integer may not
+exceed :math:`10^{-8}`. An arbitrary wavelength is allowed when the
+propagation direction has open boundaries.
+
+.. describe:: cmc_spiral_axis
+
+Required only when ``cmc_constraint_mode = "spin_spiral"``. A finite,
+nonzero Cartesian vector defining the spin-space rotation axis
+:math:`\hat{\vec{a}}`. It is normalised internally.
+
+For example, a planar spiral making one turn over four periodic unit cells in
+the :math:`a` direction is configured with
+
+.. code-block:: cfg
+
+    cmc_constraint_mode = "spin_spiral";
+    cmc_constraint_type = "magnetisation";
+    cmc_constraint_theta = 90.0;
+    cmc_constraint_phi = 0.0;
+    cmc_spiral_wavevector = [0.25, 0.0, 0.0];
+    cmc_spiral_axis = [0.0, 0.0, 1.0];
+
+Every constrained plane must contain at least two nonzero-moment spins so that
+a compensation spin is available.
 
 .. describe:: cmc_constraint_tolerance = 1e-6
 

--- a/src/jams/solvers/cpu_monte_carlo_constrained.cc
+++ b/src/jams/solvers/cpu_monte_carlo_constrained.cc
@@ -1,6 +1,8 @@
 // Copyright 2014 Joseph Barker. All rights reserved.
 #include <cmath>
 #include <iomanip>
+#include <map>
+#include <sstream>
 
 #include <libconfig.h++>
 
@@ -21,11 +23,25 @@
 #include "jams/helpers/montecarlo.h"
 
 namespace {
+    constexpr double kSpiralCommensurabilityTolerance = 1.0e-8;
+
     inline double remap_azimuthal_angle_degrees(double x) {
       // remaps an angle in degrees to the range -180.0 < x <= 180.0
       // this matches the mapping expected for atan2 but avoids the ambiguity
       // of -180.0 == 180.0 which can cause issues for rotation matricies
       return (x = fmod(x + 360.0, 360.0)) > 180.0 ? x - 360.0 : x;
+    }
+
+    bool is_finite(const jams::Vec<double, 3>& vector) {
+      return std::isfinite(vector[0])
+          && std::isfinite(vector[1])
+          && std::isfinite(vector[2]);
+    }
+
+    jams::Mat<double, 3, 3> rotation_to_z(const jams::Vec<double, 3>& direction) {
+      const auto theta = jams::polar_angle(direction);
+      const auto phi = jams::azimuthal_angle(direction);
+      return rotation_matrix_y(-theta) * rotation_matrix_z(-phi);
     }
 }
 
@@ -42,6 +58,34 @@ void ConstrainedMCSolver::initialize(const libconfig::Setting& settings) {
     throw jams::ConfigException(
         settings["cmc_constraint_type"],
         "must be either 'magnetisation' or 'material_transform'");
+  }
+
+  const auto constraint_mode_name = lowercase(jams::config_optional<std::string>(
+      settings, "cmc_constraint_mode", "global"));
+  if (constraint_mode_name == "global") {
+    constraint_mode_ = ConstraintMode::Global;
+  } else if (constraint_mode_name == "spin_spiral") {
+    constraint_mode_ = ConstraintMode::SpinSpiral;
+  } else {
+    throw jams::ConfigException(
+        settings["cmc_constraint_mode"],
+        "must be either 'global' or 'spin_spiral'");
+  }
+
+  const bool has_spiral_wavevector = settings.exists("cmc_spiral_wavevector");
+  const bool has_spiral_axis = settings.exists("cmc_spiral_axis");
+  if (constraint_mode_ == ConstraintMode::Global
+      && (has_spiral_wavevector || has_spiral_axis)) {
+    throw jams::ConfigException(
+        settings,
+        "cmc_spiral_wavevector and cmc_spiral_axis are only valid when "
+        "cmc_constraint_mode is 'spin_spiral'");
+  }
+  if (constraint_mode_ == ConstraintMode::SpinSpiral
+      && (!has_spiral_wavevector || !has_spiral_axis)) {
+    throw jams::ConfigException(
+        settings,
+        "spin_spiral mode requires both cmc_spiral_wavevector and cmc_spiral_axis");
   }
 
   max_steps_ = jams::config_required<int>(settings, "max_steps");
@@ -96,6 +140,10 @@ void ConstrainedMCSolver::initialize(const libconfig::Setting& settings) {
     }
   }
 
+  if (constraint_mode_ == ConstraintMode::SpinSpiral) {
+    initialize_spin_spiral(settings);
+  }
+
   output_initialization_info(std::cout);
 
   validate_angles();
@@ -106,6 +154,107 @@ void ConstrainedMCSolver::initialize(const libconfig::Setting& settings) {
     align_spins_to_constraint();
   }
   validate_constraint();
+}
+
+void ConstrainedMCSolver::initialize_spin_spiral(const libconfig::Setting& settings) {
+  spiral_wavevector_ = jams::read_vec_setting<double, 3>(
+      settings["cmc_spiral_wavevector"], "cmc_spiral_wavevector");
+  spiral_axis_ = jams::read_vec_setting<double, 3>(
+      settings["cmc_spiral_axis"], "cmc_spiral_axis");
+
+  if (!is_finite(spiral_wavevector_)) {
+    throw jams::ConfigException(
+        settings["cmc_spiral_wavevector"],
+        "cmc_spiral_wavevector components must be finite");
+  }
+
+  int nonzero_wavevector_components = 0;
+  for (auto direction = 0; direction < 3; ++direction) {
+    if (spiral_wavevector_[direction] != 0.0) {
+      ++nonzero_wavevector_components;
+      spiral_propagation_direction_ = direction;
+    }
+  }
+  if (nonzero_wavevector_components != 1) {
+    throw jams::ConfigException(
+        settings["cmc_spiral_wavevector"],
+        "cmc_spiral_wavevector must have exactly one non-zero component");
+  }
+
+  if (!is_finite(spiral_axis_)) {
+    throw jams::ConfigException(
+        settings["cmc_spiral_axis"],
+        "cmc_spiral_axis components must be finite");
+  }
+  const double spiral_axis_norm = jams::norm(spiral_axis_);
+  if (!std::isfinite(spiral_axis_norm) || spiral_axis_norm == 0.0) {
+    throw jams::ConfigException(
+        settings["cmc_spiral_axis"],
+        "cmc_spiral_axis must have a finite, non-zero length");
+  }
+  spiral_axis_ /= spiral_axis_norm;
+
+  const double wavevector_component = spiral_wavevector_[spiral_propagation_direction_];
+  if (globals::lattice->is_periodic(spiral_propagation_direction_)) {
+    const double supercell_turns = wavevector_component
+        * static_cast<double>(globals::lattice->size(spiral_propagation_direction_));
+    const double nearest_integer_turns = std::round(supercell_turns);
+    if (!std::isfinite(supercell_turns)
+        || std::abs(supercell_turns - nearest_integer_turns)
+            > kSpiralCommensurabilityTolerance) {
+      throw jams::ConfigException(
+          settings["cmc_spiral_wavevector"],
+          "component ", spiral_propagation_direction_, " with supercell length ",
+          globals::lattice->size(spiral_propagation_direction_),
+          " gives ", supercell_turns,
+          " turns; periodic spin spirals must be commensurate within ",
+          kSpiralCommensurabilityTolerance,
+          " turns of the nearest integer (", nearest_integer_turns, ")");
+    }
+  }
+
+  std::map<int, int> plane_indices;
+  for (auto spin = 0; spin < globals::num_spins; ++spin) {
+    const int coordinate = globals::lattice->cell_offset(spin)[spiral_propagation_direction_];
+    plane_indices.emplace(coordinate, 0);
+  }
+
+  constraint_planes_.reserve(plane_indices.size());
+  int plane_index = 0;
+  for (auto& [coordinate, index] : plane_indices) {
+    index = plane_index++;
+
+    ConstraintPlane plane;
+    plane.coordinate = coordinate;
+    const double phase = kTwoPi * wavevector_component * static_cast<double>(coordinate);
+    plane.target_direction = rotation_matrix_from_axis_angle(spiral_axis_, phase)
+        * constraint_vector_;
+    plane.rotation_matrix = rotation_to_z(plane.target_direction);
+    plane.inverse_rotation_matrix = transpose(plane.rotation_matrix);
+    constraint_planes_.push_back(std::move(plane));
+  }
+
+  spin_constraint_group_.assign(globals::num_spins, -1);
+  for (auto spin = 0; spin < globals::num_spins; ++spin) {
+    const int coordinate = globals::lattice->cell_offset(spin)[spiral_propagation_direction_];
+    const int group = plane_indices.at(coordinate);
+    spin_constraint_group_[spin] = group;
+    constraint_planes_[group].spins.push_back(spin);
+    if (globals::inv_mus(spin) != 0.0) {
+      constraint_planes_[group].magnetic_spins.push_back(spin);
+    }
+  }
+
+  for (const auto& plane : constraint_planes_) {
+    if (plane.magnetic_spins.size() < 2) {
+      throw jams::ConfigException(
+          settings,
+          "spin-spiral plane normal to lattice direction ",
+          spiral_propagation_direction_, " at cell coordinate ", plane.coordinate,
+          " contains ", plane.magnetic_spins.size(),
+          " non-zero-moment spins; at least two are required");
+    }
+  }
 }
 
 void ConstrainedMCSolver::run() {
@@ -154,18 +303,31 @@ unsigned ConstrainedMCSolver::AsselinAlgorithm(const std::function<jams::Vec<dou
   std::uniform_real_distribution<> uniform_distribution;
 
   const double temperature = physics_module_->temperature();
-  jams::Vec<double, 3> order_parameter = total_constraint_vector();
+  auto order_parameters = constraint_vectors();
 
   unsigned moves_accepted = 0;
 
   // we move two spins moving all spins on average is num_spins/2
   for (auto i = 0; i < globals::num_spins/2; ++i) {
-    // randomly get two spins s1 != s2
+    // Randomly get two spins s1 != s2. For a spin spiral both spins must
+    // belong to the same constrained plane.
     auto s1 = jams::montecarlo::random_spin_index();
+    const int group = constraint_group_index(s1);
 
     auto s2 = s1;
-    while (s2 == s1) {
-      s2 = jams::montecarlo::random_spin_index();
+    if (constraint_mode_ == ConstraintMode::Global) {
+      while (s2 == s1) {
+        s2 = jams::montecarlo::random_spin_index();
+      }
+    } else {
+      if (globals::inv_mus(s1) == 0.0) {
+        continue;
+      }
+      const auto& compensation_spins = constraint_planes_[group].magnetic_spins;
+      while (s2 == s1) {
+        const auto partner_index = jams::instance().random_generator()(compensation_spins.size());
+        s2 = compensation_spins[partner_index];
+      }
     }
 
     jams::Vec<double, 3> s1_initial         = jams::montecarlo::get_spin(s1);
@@ -198,15 +360,18 @@ unsigned ConstrainedMCSolver::AsselinAlgorithm(const std::function<jams::Vec<dou
     jams::Vec<double, 3> delta_order_parameter = constraint_vector_difference(
         s1, s1_initial, s1_trial, s2, s2_initial, s2_trial);
 
+    const auto& group_rotation_matrix = rotation_matrix(group);
+    auto& order_parameter = order_parameters[group];
     jams::Vec<double, 3> trial_order_parameter_rotated =
-        rotation_matrix_ * (order_parameter + delta_order_parameter);
+        group_rotation_matrix * (order_parameter + delta_order_parameter);
 
     if (trial_order_parameter_rotated[2] < 0.0) {
       // The new order parameter is in the opposite sense - reject the move.
       continue;
     }
 
-    jams::Vec<double, 3> initial_order_parameter_rotated = rotation_matrix_ * order_parameter;
+    jams::Vec<double, 3> initial_order_parameter_rotated =
+        group_rotation_matrix * order_parameter;
 
     // calculate the Boltzmann weighted probability including the Jacobian factors (see paper)
     double delta_e = energy_difference(s1, s1_initial, s1_trial, s2, s2_initial, s2_trial);
@@ -275,6 +440,48 @@ jams::Vec<double, 3> ConstrainedMCSolver::total_constraint_vector() const {
   return total;
 }
 
+std::vector<jams::Vec<double, 3>> ConstrainedMCSolver::constraint_vectors() const {
+  if (constraint_mode_ == ConstraintMode::Global) {
+    return {total_constraint_vector()};
+  }
+
+  std::vector<jams::Vec<double, 3>> totals(
+      constraint_planes_.size(), jams::Vec<double, 3>{{0.0, 0.0, 0.0}});
+  for (auto spin = 0; spin < globals::num_spins; ++spin) {
+    totals[spin_constraint_group_[spin]] += globals::mus(spin)
+        * spin_to_order_parameter(spin, jams::montecarlo::get_spin(spin));
+  }
+  return totals;
+}
+
+int ConstrainedMCSolver::constraint_group_index(const int spin_index) const {
+  if (constraint_mode_ == ConstraintMode::Global) {
+    return 0;
+  }
+  return spin_constraint_group_[spin_index];
+}
+
+const jams::Vec<double, 3>& ConstrainedMCSolver::target_direction(const int group_index) const {
+  if (constraint_mode_ == ConstraintMode::Global) {
+    return constraint_vector_;
+  }
+  return constraint_planes_[group_index].target_direction;
+}
+
+const jams::Mat<double, 3, 3>& ConstrainedMCSolver::rotation_matrix(const int group_index) const {
+  if (constraint_mode_ == ConstraintMode::Global) {
+    return rotation_matrix_;
+  }
+  return constraint_planes_[group_index].rotation_matrix;
+}
+
+const jams::Mat<double, 3, 3>& ConstrainedMCSolver::inverse_rotation_matrix(const int group_index) const {
+  if (constraint_mode_ == ConstraintMode::Global) {
+    return inverse_rotation_matrix_;
+  }
+  return constraint_planes_[group_index].inverse_rotation_matrix;
+}
+
 jams::Vec<double, 3> ConstrainedMCSolver::spin_to_order_parameter(const int &i, const jams::Vec<double, 3> &spin) const {
   return constraint_transformations_[i] * spin;
 }
@@ -284,11 +491,12 @@ jams::Vec<double, 3> ConstrainedMCSolver::order_parameter_to_spin(const int &i, 
 }
 
 jams::Vec<double, 3> ConstrainedMCSolver::rotate_cartesian_to_constraint(const int &i, const jams::Vec<double, 3> &spin) const {
-  return rotation_matrix_ * spin_to_order_parameter(i, spin);
+  return rotation_matrix(constraint_group_index(i)) * spin_to_order_parameter(i, spin);
 }
 
 jams::Vec<double, 3> ConstrainedMCSolver::rotate_constraint_to_cartesian(const int &i, const jams::Vec<double, 3> &spin) const {
-  return order_parameter_to_spin(i, inverse_rotation_matrix_ * spin);
+  return order_parameter_to_spin(
+      i, inverse_rotation_matrix(constraint_group_index(i)) * spin);
 }
 
 const char* ConstrainedMCSolver::constraint_type_name() const {
@@ -301,49 +509,86 @@ const char* ConstrainedMCSolver::constraint_type_name() const {
   return "unknown";
 }
 
+const char* ConstrainedMCSolver::constraint_mode_name() const {
+  switch (constraint_mode_) {
+    case ConstraintMode::Global:
+      return "global";
+    case ConstraintMode::SpinSpiral:
+      return "spin_spiral";
+  }
+  return "unknown";
+}
+
 void ConstrainedMCSolver::output_initialization_info(std::ostream &os) {
+  os << "    constraint mode " << constraint_mode_name() << "\n";
   os << "    constraint type " << constraint_type_name() << "\n";
   os << "    constraint angle theta (deg) " << constraint_theta_ << "\n";
   os << "    constraint angle phi (deg) " << constraint_phi_ << "\n";
   os << "    constraint angular tolerance (deg) " << constraint_tolerance_degrees_ << "\n";
-  os << "    constraint vector " << constraint_vector_[0] << " " << constraint_vector_[1] << " " << constraint_vector_[2] << "\n";
+  os << "    "
+     << (constraint_mode_ == ConstraintMode::Global
+             ? "constraint vector " : "reference constraint vector ")
+     << constraint_vector_[0] << " " << constraint_vector_[1] << " "
+     << constraint_vector_[2] << "\n";
+  if (constraint_mode_ == ConstraintMode::SpinSpiral) {
+    os << "    spiral wavevector " << spiral_wavevector_ << " (cycles per unit cell)\n";
+    os << "    spiral rotation axis " << spiral_axis_ << "\n";
+    os << "    spiral propagation lattice direction " << spiral_propagation_direction_ << "\n";
+    os << "    constrained planes " << constraint_planes_.size() << "\n";
+    for (const auto& plane : constraint_planes_) {
+      os << "      coordinate " << plane.coordinate
+         << ": " << plane.magnetic_spins.size() << " magnetic spins\n";
+    }
+  }
   os << "    move_fraction_uniform " << move_fraction_uniform_ << "\n";
   os << "    move_fraction_angle " << move_fraction_angle_ << "\n";
   os << "    move_fraction_reflection " << move_fraction_reflection_ << "\n";
   os << "    move_angle_sigma " << move_angle_sigma_ << "\n";
   os << "    output_write_steps " << output_write_steps_ << "\n";
-  os << "    rotation matrix m -> mz\n";
-  for (auto i = 0; i < 3; ++i) {
-    os << "      ";
-    for (auto j = 0; j < 3; ++j) {
-      os << rotation_matrix_[i][j] << " ";
+  if (constraint_mode_ == ConstraintMode::Global) {
+    os << "    rotation matrix m -> mz\n";
+    for (auto i = 0; i < 3; ++i) {
+      os << "      ";
+      for (auto j = 0; j < 3; ++j) {
+        os << rotation_matrix_[i][j] << " ";
+      }
+      os << "\n";
     }
-    os << "\n";
-  }
-  os << "    inverse rotation matrix mz -> m\n";
-  for (auto i = 0; i < 3; ++i) {
-    os << "      ";
-    for (auto j = 0; j < 3; ++j) {
-      os << inverse_rotation_matrix_[i][j] << " ";
+    os << "    inverse rotation matrix mz -> m\n";
+    for (auto i = 0; i < 3; ++i) {
+      os << "      ";
+      for (auto j = 0; j < 3; ++j) {
+        os << inverse_rotation_matrix_[i][j] << " ";
+      }
+      os << "\n";
     }
-    os << "\n";
   }
 }
 
 void ConstrainedMCSolver::validate_rotation_matricies() const {
-  jams::Vec<double, 3> test_unit_vec = {0.0, 0.0, 1.0};
-  jams::Vec<double, 3> test_forward_vec = rotation_matrix_ * test_unit_vec;
-  jams::Vec<double, 3> test_back_vec    = inverse_rotation_matrix_ * test_forward_vec;
+  const jams::Vec<double, 3> constraint_axis = {0.0, 0.0, 1.0};
+  const int group_count = constraint_mode_ == ConstraintMode::Global
+      ? 1 : static_cast<int>(constraint_planes_.size());
 
-  std::cout << "  rotation sanity check\n";
-  std::cout << "    rotate\n";
-  std::cout << "      " << test_unit_vec << " -> " << test_forward_vec << "\n";
-  std::cout << "    back rotate\n";
-  std::cout << "      " << test_forward_vec << " -> " << test_back_vec << "\n";
+  std::cout << "  rotation sanity check for " << group_count
+            << " constraint group" << (group_count == 1 ? "" : "s") << "\n";
 
-  for (int n = 0; n < 3; ++n) {
-    if (!approximately_equal(test_unit_vec[n], test_back_vec[n], jams::defaults::solver_monte_carlo_constraint_tolerance)) {
-      throw std::runtime_error("ConstrainedMCSolver :: rotation sanity check failed");
+  for (auto group = 0; group < group_count; ++group) {
+    const auto& requested_direction = target_direction(group);
+    const auto test_forward_vec = rotation_matrix(group) * requested_direction;
+    const auto test_back_vec = inverse_rotation_matrix(group) * test_forward_vec;
+
+    for (int component = 0; component < 3; ++component) {
+      if (!approximately_equal(
+              constraint_axis[component], test_forward_vec[component],
+              jams::defaults::solver_monte_carlo_constraint_tolerance)
+          || !approximately_equal(
+              requested_direction[component], test_back_vec[component],
+              jams::defaults::solver_monte_carlo_constraint_tolerance)) {
+        throw std::runtime_error(
+            "ConstrainedMCSolver :: rotation sanity check failed for constraint group "
+            + std::to_string(group));
+      }
     }
   }
 }
@@ -370,36 +615,60 @@ void ConstrainedMCSolver::output_running_stats_info(std::ostream &os) {
 
 
 void ConstrainedMCSolver::validate_constraint() const {
-  const auto order_parameter = total_constraint_vector();
+  const auto order_parameters = constraint_vectors();
+  if (constraint_mode_ == ConstraintMode::Global) {
+    validate_constraint_vector(
+        order_parameters.front(), constraint_vector_, "the total constraint vector");
+    return;
+  }
+
+  for (auto group = 0; group < constraint_planes_.size(); ++group) {
+    const auto& plane = constraint_planes_[group];
+    validate_constraint_vector(
+        order_parameters[group],
+        plane.target_direction,
+        "spin-spiral plane normal to lattice direction "
+            + std::to_string(spiral_propagation_direction_)
+            + " at cell coordinate " + std::to_string(plane.coordinate));
+  }
+}
+
+void ConstrainedMCSolver::validate_constraint_vector(
+    const jams::Vec<double, 3>& order_parameter,
+    const jams::Vec<double, 3>& target_direction,
+    const std::string& description) const {
   const double order_parameter_norm = jams::norm(order_parameter);
 
-  if (!std::isfinite(order_parameter[0])
-      || !std::isfinite(order_parameter[1])
-      || !std::isfinite(order_parameter[2])
+  if (!is_finite(order_parameter)
       || !std::isfinite(order_parameter_norm)
       || order_parameter_norm == 0.0) {
     std::stringstream ss;
-    ss << "ConstrainedMCSolver -- constraint direction is undefined because the total constraint vector is zero or non-finite ("
+    ss << "ConstrainedMCSolver -- constraint direction is undefined for "
+       << description << " because its vector is zero or non-finite ("
        << std::scientific << std::setprecision(12)
        << order_parameter[0] << ", " << order_parameter[1] << ", " << order_parameter[2] << ")";
     throw std::runtime_error(ss.str());
   }
 
   const double angular_error_degrees = rad_to_deg(std::atan2(
-      jams::norm(jams::cross(order_parameter, constraint_vector_)),
-      jams::dot(order_parameter, constraint_vector_)));
+      jams::norm(jams::cross(order_parameter, target_direction)),
+      jams::dot(order_parameter, target_direction)));
   if (!std::isfinite(angular_error_degrees)) {
     throw std::runtime_error(
-        "ConstrainedMCSolver -- constraint direction is undefined because its angular difference is non-finite");
+        "ConstrainedMCSolver -- constraint direction is undefined for " + description
+        + " because its angular difference is non-finite");
   }
 
   if (angular_error_degrees > constraint_tolerance_degrees_) {
     const double actual_theta = rad_to_deg(jams::polar_angle(order_parameter));
     const double actual_phi = rad_to_deg(jams::azimuthal_angle(order_parameter));
+    const double requested_theta = rad_to_deg(jams::polar_angle(target_direction));
+    const double requested_phi = rad_to_deg(jams::azimuthal_angle(target_direction));
     std::stringstream ss;
-    ss << "ConstrainedMCSolver -- constraint direction violated (requested theta "
-       << std::fixed << std::setprecision(10) << constraint_theta_ << " deg, phi "
-       << constraint_phi_ << " deg; actual theta " << actual_theta << " deg, phi "
+    ss << "ConstrainedMCSolver -- constraint direction violated for " << description
+       << " (requested theta "
+       << std::fixed << std::setprecision(10) << requested_theta << " deg, phi "
+       << requested_phi << " deg; actual theta " << actual_theta << " deg, phi "
        << actual_phi << " deg; angular difference "
        << std::scientific << std::setprecision(12) << angular_error_degrees
        << " deg exceeds tolerance " << constraint_tolerance_degrees_ << " deg)";
@@ -446,16 +715,58 @@ void ConstrainedMCSolver::sum_running_acceptance_statistics() {
 }
 
 void ConstrainedMCSolver::align_spins_to_constraint() const {
-  const auto order_parameter = total_constraint_vector();
+  const auto require_defined_direction = [](
+      const jams::Vec<double, 3>& vector,
+      const std::string& description) {
+    const double vector_norm = jams::norm(vector);
+    if (!is_finite(vector) || !std::isfinite(vector_norm) || vector_norm == 0.0) {
+      std::stringstream ss;
+      ss << "ConstrainedMCSolver -- constraint direction is undefined for "
+         << description << " because its vector is zero or non-finite ("
+         << std::scientific << std::setprecision(12)
+         << vector[0] << ", " << vector[1] << ", " << vector[2] << ")";
+      throw std::runtime_error(ss.str());
+    }
+  };
 
-  const auto rotation = rotation_matrix_between_vectors(order_parameter, constraint_vector_);
+  if (constraint_mode_ == ConstraintMode::Global) {
+    const auto order_parameter = total_constraint_vector();
+    require_defined_direction(order_parameter, "the total constraint vector");
+    const auto rotation = rotation_matrix_between_vectors(
+        order_parameter, constraint_vector_);
 
-  for (auto i = 0; i < globals::num_spins; ++i) {
-    const auto spin = jams::montecarlo::get_spin(i);
-    const auto aligned_order_parameter_spin = rotation * spin_to_order_parameter(i, spin);
-    const auto aligned_spin = order_parameter_to_spin(i, aligned_order_parameter_spin);
-    for (auto j : {0, 1, 2}) {
-      globals::s(i, j) = aligned_spin[j];
+    for (auto spin_index = 0; spin_index < globals::num_spins; ++spin_index) {
+      const auto spin = jams::montecarlo::get_spin(spin_index);
+      const auto aligned_order_parameter_spin = rotation
+          * spin_to_order_parameter(spin_index, spin);
+      const auto aligned_spin = order_parameter_to_spin(
+          spin_index, aligned_order_parameter_spin);
+      for (auto component : {0, 1, 2}) {
+        globals::s(spin_index, component) = aligned_spin[component];
+      }
+    }
+    return;
+  }
+
+  const auto order_parameters = constraint_vectors();
+  for (auto group = 0; group < constraint_planes_.size(); ++group) {
+    const auto& plane = constraint_planes_[group];
+    const auto description = "spin-spiral plane normal to lattice direction "
+        + std::to_string(spiral_propagation_direction_)
+        + " at cell coordinate " + std::to_string(plane.coordinate);
+    require_defined_direction(order_parameters[group], description);
+    const auto alignment = rotation_matrix_between_vectors(
+        order_parameters[group], plane.target_direction);
+
+    for (const auto spin_index : plane.spins) {
+      const auto spin = jams::montecarlo::get_spin(spin_index);
+      const auto aligned_order_parameter_spin = alignment
+          * spin_to_order_parameter(spin_index, spin);
+      const auto aligned_spin = order_parameter_to_spin(
+          spin_index, aligned_order_parameter_spin);
+      for (auto component : {0, 1, 2}) {
+        globals::s(spin_index, component) = aligned_spin[component];
+      }
     }
   }
 }

--- a/src/jams/solvers/cpu_monte_carlo_constrained.h
+++ b/src/jams/solvers/cpu_monte_carlo_constrained.h
@@ -5,6 +5,7 @@
 
 #include <random>
 #include <fstream>
+#include <vector>
 
 #include <jams/core/types.h>
 #include "jams/core/solver.h"
@@ -35,15 +36,36 @@ class ConstrainedMCSolver : public Solver {
       MaterialTransform
     };
 
+    enum class ConstraintMode {
+      Global,
+      SpinSpiral
+    };
+
+    struct ConstraintPlane {
+      int coordinate = 0;
+      jams::Vec<double, 3> target_direction = {{0.0, 0.0, 1.0}};
+      jams::Mat<double, 3, 3> rotation_matrix = kIdentityMat3;
+      jams::Mat<double, 3, 3> inverse_rotation_matrix = kIdentityMat3;
+      std::vector<int> spins;
+      std::vector<int> magnetic_spins;
+    };
+
     void output_initialization_info(std::ostream &os);
     void output_running_stats_info(std::ostream &os);
 
     const char* constraint_type_name() const;
+    const char* constraint_mode_name() const;
+
+    void initialize_spin_spiral(const libconfig::Setting& settings);
 
     void validate_angles() const;
     void validate_rotation_matricies() const;
     void validate_moves() const;
     void validate_constraint() const;
+    void validate_constraint_vector(
+        const jams::Vec<double, 3>& order_parameter,
+        const jams::Vec<double, 3>& target_direction,
+        const std::string& description) const;
 
     void sum_running_acceptance_statistics();
     void reset_running_statistics();
@@ -57,6 +79,11 @@ class ConstrainedMCSolver : public Solver {
     jams::Vec<double, 3>     rotate_cartesian_to_constraint(const int &i, const jams::Vec<double, 3> &spin) const;
     jams::Vec<double, 3>     rotate_constraint_to_cartesian(const int &i, const jams::Vec<double, 3> &spin) const;
     jams::Vec<double, 3>     total_constraint_vector() const;
+    std::vector<jams::Vec<double, 3>> constraint_vectors() const;
+    int constraint_group_index(int spin_index) const;
+    const jams::Vec<double, 3>& target_direction(int group_index) const;
+    const jams::Mat<double, 3, 3>& rotation_matrix(int group_index) const;
+    const jams::Mat<double, 3, 3>& inverse_rotation_matrix(int group_index) const;
 
     double   energy_difference(const int &s1, const jams::Vec<double, 3> &s1_initial, const jams::Vec<double, 3> &s1_trial, const int &s2, const jams::Vec<double, 3> &s2_initial, const jams::Vec<double, 3> &s2_trial) const;
     jams::Vec<double, 3>     constraint_vector_difference(const int &s1, const jams::Vec<double, 3> &s1_initial, const jams::Vec<double, 3> &s1_trial, const int &s2, const jams::Vec<double, 3> &s2_initial, const jams::Vec<double, 3> &s2_trial) const;
@@ -64,6 +91,7 @@ class ConstrainedMCSolver : public Solver {
     bool do_spin_initial_alignment_ = true;
 
     ConstraintType constraint_type_ = ConstraintType::MaterialTransform;
+    ConstraintMode constraint_mode_ = ConstraintMode::Global;
 
     double constraint_theta_   = 0.0;
     double constraint_phi_     = 0.0;
@@ -75,6 +103,12 @@ class ConstrainedMCSolver : public Solver {
     jams::Mat<double, 3, 3> inverse_rotation_matrix_ = kIdentityMat3;
 
     std::vector<jams::Mat<double, 3, 3>> constraint_transformations_;
+
+    jams::Vec<double, 3> spiral_wavevector_ = {{0.0, 0.0, 0.0}};
+    jams::Vec<double, 3> spiral_axis_ = {{0.0, 0.0, 1.0}};
+    int spiral_propagation_direction_ = -1;
+    std::vector<ConstraintPlane> constraint_planes_;
+    std::vector<int> spin_constraint_group_;
 
     int output_write_steps_ = 100;
 

--- a/src/jams/test/solvers/test_cpu_monte_carlo_constrained.h
+++ b/src/jams/test/solvers/test_cpu_monte_carlo_constrained.h
@@ -1,6 +1,7 @@
 #ifndef JAMS_TEST_SOLVERS_TEST_CPU_MONTE_CARLO_CONSTRAINED_H
 #define JAMS_TEST_SOLVERS_TEST_CPU_MONTE_CARLO_CONSTRAINED_H
 
+#include <algorithm>
 #include <cmath>
 #include <functional>
 #include <iomanip>
@@ -52,7 +53,12 @@ std::string constrained_mc_config(
     const std::string& constraint_type,
     const double theta,
     const double phi,
-    const bool auto_align) {
+    const bool auto_align,
+    const std::string& constraint_mode = "",
+    const std::optional<jams::Vec<double, 3>>& spiral_wavevector = std::nullopt,
+    const std::optional<jams::Vec<double, 3>>& spiral_axis = std::nullopt,
+    const jams::Vec<int, 3>& lattice_size = {1, 1, 1},
+    const jams::Vec<bool, 3>& periodic = {true, true, true}) {
   std::ostringstream config;
   config << std::fixed << std::setprecision(15);
   config << R"(
@@ -64,6 +70,21 @@ std::string constrained_mc_config(
       auto_align = )" << (auto_align ? "true" : "false") << ";\n";
   if (!constraint_type.empty()) {
     config << "      cmc_constraint_type = \"" << constraint_type << "\";\n";
+  }
+  if (!constraint_mode.empty()) {
+    config << "      cmc_constraint_mode = \"" << constraint_mode << "\";\n";
+  }
+  if (spiral_wavevector.has_value()) {
+    config << "      cmc_spiral_wavevector = ["
+           << (*spiral_wavevector)[0] << ", "
+           << (*spiral_wavevector)[1] << ", "
+           << (*spiral_wavevector)[2] << "];\n";
+  }
+  if (spiral_axis.has_value()) {
+    config << "      cmc_spiral_axis = ["
+           << (*spiral_axis)[0] << ", "
+           << (*spiral_axis)[1] << ", "
+           << (*spiral_axis)[2] << "];\n";
   }
   config << "      cmc_constraint_theta = " << theta << ";\n"
          << "      cmc_constraint_phi = " << phi << ";\n"
@@ -107,9 +128,12 @@ std::string constrained_mc_config(
     };
 
     lattice = {
-      size = [1, 1, 1];
-      periodic = [true, true, true];
-    };
+      size = [)" << lattice_size[0] << ", " << lattice_size[1] << ", "
+         << lattice_size[2] << "];\n"
+         << "      periodic = [" << (periodic[0] ? "true" : "false") << ", "
+         << (periodic[1] ? "true" : "false") << ", "
+         << (periodic[2] ? "true" : "false") << "];\n"
+         << R"(    };
   )";
   return config.str();
 }
@@ -123,6 +147,44 @@ jams::Vec<double, 3> constrained_mc_total(const bool apply_material_transform) {
           globals::lattice->lattice_site_material_id(i)).transform * spin;
     }
     total += globals::mus(i) * spin;
+  }
+  return total;
+}
+
+jams::Vec<double, 3> constrained_mc_plane_total(
+    const int propagation_direction,
+    const int plane_coordinate,
+    const bool apply_material_transform) {
+  jams::Vec<double, 3> total = {0.0, 0.0, 0.0};
+  for (auto spin_index = 0; spin_index < globals::num_spins; ++spin_index) {
+    if (globals::lattice->cell_offset(spin_index)[propagation_direction]
+        != plane_coordinate) {
+      continue;
+    }
+    auto spin = jams::montecarlo::get_spin(spin_index);
+    if (apply_material_transform) {
+      spin = globals::lattice->material(
+          globals::lattice->lattice_site_material_id(spin_index)).transform * spin;
+    }
+    total += globals::mus(spin_index) * spin;
+  }
+  return total;
+}
+
+jams::Vec<double, 3> constrained_mc_cell_total(
+    const jams::Vec<int, 3>& cell_offset,
+    const bool apply_material_transform) {
+  jams::Vec<double, 3> total = {0.0, 0.0, 0.0};
+  for (auto spin_index = 0; spin_index < globals::num_spins; ++spin_index) {
+    if (globals::lattice->cell_offset(spin_index) != cell_offset) {
+      continue;
+    }
+    auto spin = jams::montecarlo::get_spin(spin_index);
+    if (apply_material_transform) {
+      spin = globals::lattice->material(
+          globals::lattice->lattice_site_material_id(spin_index)).transform * spin;
+    }
+    total += globals::mus(spin_index) * spin;
   }
   return total;
 }
@@ -142,6 +204,16 @@ void expect_unit_spins() {
   }
 }
 
+void add_vec_setting(
+    libconfig::Setting& parent,
+    const char* name,
+    const jams::Vec<double, 3>& value) {
+  auto& setting = parent.add(name, libconfig::Setting::TypeArray);
+  for (auto component = 0; component < 3; ++component) {
+    setting.add(libconfig::Setting::TypeFloat) = value[component];
+  }
+}
+
 }  // namespace
 
 class ConstrainedMCSolverConstraintTest : public ::testing::Test {
@@ -156,15 +228,11 @@ class ConstrainedMCSolverConstraintTest : public ::testing::Test {
     jams::testing::toggle_cout();
   }
 
-  std::unique_ptr<ConstrainedMCSolver> make_solver(
-      const std::string& constraint_type,
-      const double theta,
-      const double phi,
-      const bool auto_align,
+  std::unique_ptr<ConstrainedMCSolver> make_solver_from_config(
+      const std::string& config_text,
       const std::optional<double> constraint_tolerance = std::nullopt,
       const std::function<void()>& prepare_spins = {}) {
     globals::config = std::make_unique<libconfig::Config>();
-    const auto config_text = constrained_mc_config(constraint_type, theta, phi, auto_align);
     globals::config->readString(config_text.c_str());
     if (constraint_tolerance.has_value()) {
       globals::config->lookup("solver")
@@ -176,6 +244,59 @@ class ConstrainedMCSolverConstraintTest : public ::testing::Test {
       prepare_spins();
     }
     return std::make_unique<ConstrainedMCSolver>(globals::config->lookup("solver"));
+  }
+
+  std::unique_ptr<ConstrainedMCSolver> make_solver(
+      const std::string& constraint_type,
+      const double theta,
+      const double phi,
+      const bool auto_align,
+      const std::optional<double> constraint_tolerance = std::nullopt,
+      const std::function<void()>& prepare_spins = {}) {
+    const auto config_text = constrained_mc_config(constraint_type, theta, phi, auto_align);
+    return make_solver_from_config(config_text, constraint_tolerance, prepare_spins);
+  }
+
+  std::unique_ptr<ConstrainedMCSolver> make_spiral_solver(
+      const std::string& constraint_type,
+      const double theta,
+      const double phi,
+      const bool auto_align,
+      const jams::Vec<double, 3>& wavevector,
+      const jams::Vec<double, 3>& axis,
+      const jams::Vec<int, 3>& lattice_size = {4, 2, 1},
+      const jams::Vec<bool, 3>& periodic = {true, true, true},
+      const std::optional<double> constraint_tolerance = std::nullopt,
+      const std::function<void()>& prepare_spins = {}) {
+    const auto config_text = constrained_mc_config(
+        constraint_type,
+        theta,
+        phi,
+        auto_align,
+        "spin_spiral",
+        wavevector,
+        axis,
+        lattice_size,
+        periodic);
+    return make_solver_from_config(config_text, constraint_tolerance, prepare_spins);
+  }
+
+  std::unique_ptr<ConstrainedMCSolver> make_programmatic_spiral_solver(
+      const jams::Vec<double, 3>& wavevector,
+      const jams::Vec<double, 3>& axis) {
+    globals::config = std::make_unique<libconfig::Config>();
+    const auto config_text = constrained_mc_config(
+        "magnetisation", 90.0, 0.0, true, "", std::nullopt, std::nullopt,
+        {4, 2, 1}, {true, true, true});
+    globals::config->readString(config_text.c_str());
+    auto& solver_settings = globals::config->lookup("solver");
+    solver_settings.add("cmc_constraint_mode", libconfig::Setting::TypeString)
+        = "spin_spiral";
+    add_vec_setting(solver_settings, "cmc_spiral_wavevector", wavevector);
+    add_vec_setting(solver_settings, "cmc_spiral_axis", axis);
+    globals::lattice = new Lattice();
+    globals::lattice->init_from_config(*globals::config);
+    return std::make_unique<ConstrainedMCSolver>(solver_settings);
   }
 
   void exercise_pair_moves(const std::string& constraint_type, const bool transformed) {
@@ -202,6 +323,43 @@ class ConstrainedMCSolverConstraintTest : public ::testing::Test {
     const double total_change = jams::norm(final_spin_0 - initial_spin_0)
         + jams::norm(final_spin_1 - initial_spin_1);
     EXPECT_GT(total_change, 1.0e-6);
+  }
+
+  void exercise_spiral_pair_moves(
+      const std::string& constraint_type,
+      const bool transformed) {
+    constexpr double theta = 90.0;
+    constexpr double phi = 0.0;
+    const jams::Vec<double, 3> wavevector = {0.25, 0.0, 0.0};
+    const jams::Vec<double, 3> axis = {0.0, 0.0, 1.0};
+    auto solver = make_spiral_solver(
+        constraint_type, theta, phi, true, wavevector, axis);
+    solver->register_physics_module(Physics::create(globals::config->lookup("physics")));
+
+    jams::instance().random_generator().seed(24680u);
+    for (auto step = 0; step < 128; ++step) {
+      ASSERT_NO_THROW(solver->run());
+    }
+
+    const jams::Vec<double, 3> reference = {1.0, 0.0, 0.0};
+    double maximum_cell_angular_error = 0.0;
+    for (auto plane = 0; plane < 4; ++plane) {
+      const auto expected = rotation_matrix_from_axis_angle(
+          axis, kTwoPi * wavevector[0] * static_cast<double>(plane)) * reference;
+      expect_direction(constrained_mc_plane_total(0, plane, transformed), expected);
+
+      for (auto transverse_cell = 0; transverse_cell < 2; ++transverse_cell) {
+        const auto cell_vector = constrained_mc_cell_total(
+            {plane, transverse_cell, 0}, transformed);
+        const double angular_error = std::atan2(
+            jams::norm(jams::cross(cell_vector, expected)),
+            jams::dot(cell_vector, expected));
+        maximum_cell_angular_error = std::max(
+            maximum_cell_angular_error, angular_error);
+      }
+    }
+    expect_unit_spins();
+    EXPECT_GT(maximum_cell_angular_error, 1.0e-6);
   }
 };
 
@@ -234,6 +392,220 @@ TEST_F(ConstrainedMCSolverConstraintTest, ModesRejectTheOtherCollectiveVectorDir
 
 TEST_F(ConstrainedMCSolverConstraintTest, RejectsUnknownConstraintType) {
   EXPECT_THROW(make_solver("sublattice", 90.0, 0.0, false), jams::ConfigException);
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, ConstraintModeIsCaseInsensitive) {
+  const auto config_text = constrained_mc_config(
+      "material_transform", 90.0, 0.0, false, "GlObAl");
+  EXPECT_NO_THROW(make_solver_from_config(config_text));
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, RejectsUnknownConstraintMode) {
+  const auto config_text = constrained_mc_config(
+      "material_transform", 90.0, 0.0, false, "unit_cell");
+  EXPECT_THROW(make_solver_from_config(config_text), jams::ConfigException);
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, SpinSpiralRequiresWavevectorAndAxis) {
+  const jams::Vec<double, 3> wavevector = {0.25, 0.0, 0.0};
+  const jams::Vec<double, 3> axis = {0.0, 0.0, 1.0};
+  const auto missing_axis = constrained_mc_config(
+      "magnetisation", 90.0, 0.0, true, "spin_spiral", wavevector,
+      std::nullopt, {4, 2, 1});
+  EXPECT_THROW(make_solver_from_config(missing_axis), jams::ConfigException);
+
+  reset_constrained_mc_globals();
+  const auto missing_wavevector = constrained_mc_config(
+      "magnetisation", 90.0, 0.0, true, "spin_spiral", std::nullopt,
+      axis, {4, 2, 1});
+  EXPECT_THROW(make_solver_from_config(missing_wavevector), jams::ConfigException);
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, GlobalModeRejectsSpiralSettings) {
+  const auto config_text = constrained_mc_config(
+      "magnetisation", 90.0, 0.0, true, "global",
+      jams::Vec<double, 3>{0.25, 0.0, 0.0},
+      jams::Vec<double, 3>{0.0, 0.0, 1.0}, {4, 2, 1});
+  EXPECT_THROW(make_solver_from_config(config_text), jams::ConfigException);
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, RejectsInvalidSpinSpiralVectors) {
+  for (const auto wavevector : {
+           jams::Vec<double, 3>{0.0, 0.0, 0.0},
+           jams::Vec<double, 3>{0.25, 0.25, 0.0}}) {
+    SCOPED_TRACE(wavevector);
+    EXPECT_THROW(
+        make_spiral_solver(
+            "magnetisation", 90.0, 0.0, true, wavevector, {0.0, 0.0, 1.0}),
+        jams::ConfigException);
+    reset_constrained_mc_globals();
+  }
+
+  EXPECT_THROW(
+      make_spiral_solver(
+          "magnetisation", 90.0, 0.0, true, {0.25, 0.0, 0.0}, {0.0, 0.0, 0.0}),
+      jams::ConfigException);
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, RejectsNonFiniteSpinSpiralVectors) {
+  const double infinity = std::numeric_limits<double>::infinity();
+  EXPECT_THROW(
+      make_programmatic_spiral_solver({infinity, 0.0, 0.0}, {0.0, 0.0, 1.0}),
+      jams::ConfigException);
+
+  reset_constrained_mc_globals();
+  EXPECT_THROW(
+      make_programmatic_spiral_solver({0.25, 0.0, 0.0}, {0.0, infinity, 1.0}),
+      jams::ConfigException);
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, ChecksPeriodicSpinSpiralCommensurability) {
+  for (const auto wavevector_component : {0.25, -0.25}) {
+    SCOPED_TRACE(wavevector_component);
+    EXPECT_NO_THROW(make_spiral_solver(
+        "magnetisation", 90.0, 0.0, true,
+        {wavevector_component, 0.0, 0.0}, {0.0, 0.0, 1.0}));
+    reset_constrained_mc_globals();
+  }
+
+  EXPECT_THROW(
+      make_spiral_solver(
+          "magnetisation", 90.0, 0.0, true,
+          {0.2, 0.0, 0.0}, {0.0, 0.0, 1.0}),
+      jams::ConfigException);
+
+  reset_constrained_mc_globals();
+  EXPECT_NO_THROW(make_spiral_solver(
+      "magnetisation", 90.0, 0.0, true,
+      {0.2, 0.0, 0.0}, {0.0, 0.0, 1.0}, {4, 2, 1}, {false, true, true}));
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, SpinSpiralAlignsPlaneMagnetisations) {
+  const jams::Vec<double, 3> wavevector = {0.25, 0.0, 0.0};
+  const jams::Vec<double, 3> axis = {0.0, 0.0, 1.0};
+  auto solver = make_spiral_solver(
+      "magnetisation", 90.0, 0.0, true, wavevector, {0.0, 0.0, 2.0});
+
+  const jams::Vec<double, 3> reference = {1.0, 0.0, 0.0};
+  for (auto plane = 0; plane < 4; ++plane) {
+    const auto expected = rotation_matrix_from_axis_angle(
+        axis, kTwoPi * wavevector[0] * static_cast<double>(plane)) * reference;
+    expect_direction(constrained_mc_plane_total(0, plane, false), expected);
+  }
+  expect_unit_spins();
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, SpinSpiralSupportsTransformedMomentsAndArbitraryAxis) {
+  auto solver = make_spiral_solver(
+      "material_transform", 0.0, 0.0, true,
+      {0.0, 0.5, 0.0}, {2.0, 0.0, 0.0}, {2, 2, 2});
+
+  expect_direction(constrained_mc_plane_total(1, 0, true), {0.0, 0.0, 1.0});
+  expect_direction(constrained_mc_plane_total(1, 1, true), {0.0, 0.0, -1.0});
+  expect_unit_spins();
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, SpinSpiralConstrainsPlaneRatherThanUnitCells) {
+  const auto prepare_plane_aggregates = [] {
+    constexpr double cell_offset_angle = 0.2;
+    for (auto spin_index = 0; spin_index < globals::num_spins; ++spin_index) {
+      const auto cell = globals::lattice->cell_offset(spin_index);
+      const jams::Vec<double, 3> target = {
+          cell[0] % 2 == 0 ? 1.0 : -1.0, 0.0, 0.0};
+      const double offset = cell[1] == 0 ? cell_offset_angle : -cell_offset_angle;
+      jams::montecarlo::set_spin(
+          spin_index, rotation_matrix_z(offset) * target);
+    }
+  };
+
+  EXPECT_NO_THROW(make_spiral_solver(
+      "magnetisation", 90.0, 0.0, false,
+      {0.5, 0.0, 0.0}, {0.0, 0.0, 1.0}, {4, 2, 1}, {true, true, true},
+      std::nullopt, prepare_plane_aggregates));
+
+  const auto cell_vector = constrained_mc_cell_total({0, 0, 0}, false);
+  const double cell_angular_error = std::atan2(
+      jams::norm(jams::cross(cell_vector, jams::Vec<double, 3>{1.0, 0.0, 0.0})),
+      jams::dot(cell_vector, jams::Vec<double, 3>{1.0, 0.0, 0.0}));
+  EXPECT_GT(cell_angular_error, 0.1);
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, EqualDirectionPlanesRemainSeparateConstraints) {
+  const auto prepare_opposite_plane_errors = [] {
+    constexpr double plane_error = 0.1;
+    for (auto spin_index = 0; spin_index < globals::num_spins; ++spin_index) {
+      const auto cell = globals::lattice->cell_offset(spin_index);
+      const jams::Vec<double, 3> target = {
+          cell[0] % 2 == 0 ? 1.0 : -1.0, 0.0, 0.0};
+      double offset = 0.0;
+      if (cell[0] == 0) {
+        offset = plane_error;
+      } else if (cell[0] == 2) {
+        offset = -plane_error;
+      }
+      jams::montecarlo::set_spin(
+          spin_index, rotation_matrix_z(offset) * target);
+    }
+  };
+
+  EXPECT_THROW(
+      make_spiral_solver(
+          "magnetisation", 90.0, 0.0, false,
+          {0.5, 0.0, 0.0}, {0.0, 0.0, 1.0}, {4, 2, 1}, {true, true, true},
+          std::nullopt, prepare_opposite_plane_errors),
+      std::runtime_error);
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, RejectsPlaneWithFewerThanTwoMagneticSpins) {
+  const auto leave_one_magnetic_spin_per_plane = [] {
+    for (auto spin_index = 0; spin_index < globals::num_spins; ++spin_index) {
+      if (globals::lattice->lattice_site_basis_index(spin_index) == 1) {
+        globals::mus(spin_index) = 0.0;
+        globals::inv_mus(spin_index) = 0.0;
+      }
+    }
+  };
+
+  EXPECT_THROW(
+      make_spiral_solver(
+          "magnetisation", 90.0, 0.0, true,
+          {0.25, 0.0, 0.0}, {0.0, 0.0, 1.0}, {4, 1, 1}, {true, true, true},
+          std::nullopt, leave_one_magnetic_spin_per_plane),
+      jams::ConfigException);
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, RejectsZeroSpinSpiralPlaneVector) {
+  const auto make_plane_vectors_zero = [] {
+    for (auto spin_index = 0; spin_index < globals::num_spins; ++spin_index) {
+      globals::mus(spin_index) = 1.0;
+      globals::inv_mus(spin_index) = 1.0;
+      jams::montecarlo::set_spin(
+          spin_index,
+          globals::lattice->lattice_site_basis_index(spin_index) == 0
+              ? jams::Vec<double, 3>{1.0, 0.0, 0.0}
+              : jams::Vec<double, 3>{-1.0, 0.0, 0.0});
+    }
+  };
+
+  EXPECT_THROW(
+      make_spiral_solver(
+          "magnetisation", 90.0, 0.0, true,
+          {0.25, 0.0, 0.0}, {0.0, 0.0, 1.0}, {4, 1, 1}, {true, true, true},
+          std::nullopt, make_plane_vectors_zero),
+      std::runtime_error);
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, RejectsNonFiniteSpinSpiralPlaneVector) {
+  const auto make_plane_vector_non_finite = [] {
+    globals::s(0, 0) = std::numeric_limits<double>::infinity();
+  };
+
+  EXPECT_THROW(
+      make_spiral_solver(
+          "magnetisation", 90.0, 0.0, true,
+          {0.25, 0.0, 0.0}, {0.0, 0.0, 1.0}, {4, 1, 1}, {true, true, true},
+          std::nullopt, make_plane_vector_non_finite),
+      std::runtime_error);
 }
 
 TEST_F(ConstrainedMCSolverConstraintTest, DefaultToleranceAcceptsRoundoffScaleDirectionalErrors) {
@@ -352,6 +724,14 @@ TEST_F(ConstrainedMCSolverConstraintTest, PairMovesPreserveMagnetisationConstrai
 
 TEST_F(ConstrainedMCSolverConstraintTest, PairMovesPreserveMaterialTransformConstraint) {
   exercise_pair_moves("material_transform", true);
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, PairMovesPreserveSpinSpiralPlaneMagnetisation) {
+  exercise_spiral_pair_moves("magnetisation", false);
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, PairMovesPreserveSpinSpiralPlaneTransformedMoments) {
+  exercise_spiral_pair_moves("material_transform", true);
 }
 
 #endif  // JAMS_TEST_SOLVERS_TEST_CPU_MONTE_CARLO_CONSTRAINED_H


### PR DESCRIPTION
Add plane-level spin-spiral constraints for magnetisation and transformed moments while retaining global constraints as the default. Group compensation candidates by constant-phase lattice planes, enforce periodic commensurability, and validate and auto-align each plane independently. Document the new configuration and extend the constrained-solver tests.