### PR TITLE
Add Q=0 plane constraints and adaptive CMC moves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,9 @@ cout
 /build
 /cmake-build*
 /.clion.source.upload.marker
-/examples
+/examples/*
+!/examples/constrained_monte_carlo/
+!/examples/constrained_monte_carlo/*.cfg
 /topological_charge
 *.h5
 *.tsv

--- a/docs/source/solvers/monte-carlo-constrained-cpu.rst
+++ b/docs/source/solvers/monte-carlo-constrained-cpu.rst
@@ -66,6 +66,15 @@ The wavevector is specified in cycles per unit cell, so the factor
 unit-cell coordinate, not merely by target direction: planes separated by a
 full turn remain independent constraints.
 
+The same plane grouping is also available at :math:`Q=0`. In this case every
+plane has target direction :math:`\hat{\vec{c}}_0`, but each plane remains a
+separate constrained collective vector and compensation spins are still
+selected from that plane. This is deliberately different from ``"global"``
+mode, which constrains only the collective vector summed over the complete
+supercell. Use the plane-constrained :math:`Q=0` form when a zero-wavevector
+reference must have the same constrained degrees of freedom as finite-
+:math:`Q` spin-spiral calculations.
+
 This Monte Carlo solver moves **two** spins for every trial. We define One Monte
 Carlo step as one trial move of every spin on average. Therefore `num_spins/2`
 trial moves of pairs of spins are made for each Monte Carlo step.
@@ -126,8 +135,14 @@ or explicitly select the material transforms with
 .. describe:: cmc_spiral_wavevector
 
 Required only when ``cmc_constraint_mode = "spin_spiral"``. A three-component
-reciprocal-lattice vector in cycles per unit cell. Exactly one component must
-be finite and nonzero; oblique and zero wavevectors are rejected.
+reciprocal-lattice vector in cycles per unit cell. Every component must be
+finite and at most one component may be nonzero; oblique wavevectors are
+rejected.
+
+For a nonzero wavevector, the propagation direction is inferred from its
+nonzero component as before. For a zero wavevector,
+``cmc_spiral_propagation_direction`` is required so that the solver knows how
+to construct the constraint planes. A zero wavevector is always commensurate.
 
 If propagation direction :math:`d` is periodic and contains :math:`L_d` unit
 cells, the spiral must satisfy
@@ -138,6 +153,15 @@ cells, the spiral must satisfy
 The numerical distance from :math:`q_dL_d` to the nearest integer may not
 exceed :math:`10^{-8}`. An arbitrary wavelength is allowed when the
 propagation direction has open boundaries.
+
+.. describe:: cmc_spiral_propagation_direction
+
+An integer selecting the lattice direction normal to the constraint planes:
+``0`` for :math:`a`, ``1`` for :math:`b`, or ``2`` for :math:`c`. This setting
+is mandatory when ``cmc_spiral_wavevector = [0.0, 0.0, 0.0]``.
+
+For a nonzero wavevector this setting is optional. If supplied, it must agree
+with the direction inferred from the nonzero wavevector component.
 
 .. describe:: cmc_spiral_axis
 
@@ -159,6 +183,35 @@ the :math:`a` direction is configured with
 
 Every constrained plane must contain at least two nonzero-moment spins so that
 a compensation spin is available.
+
+For example, the following configurations produce plane-constrained
+:math:`Q=0` references normal to the :math:`a`, :math:`b`, and :math:`c`
+directions, respectively:
+
+.. code-block:: cfg
+
+    cmc_constraint_mode = "spin_spiral";
+    cmc_spiral_wavevector = [0.0, 0.0, 0.0];
+    cmc_spiral_axis = [0.0, 0.0, 1.0];
+    cmc_spiral_propagation_direction = 0; // a planes
+
+.. code-block:: cfg
+
+    cmc_constraint_mode = "spin_spiral";
+    cmc_spiral_wavevector = [0.0, 0.0, 0.0];
+    cmc_spiral_axis = [0.0, 0.0, 1.0];
+    cmc_spiral_propagation_direction = 1; // b planes
+
+.. code-block:: cfg
+
+    cmc_constraint_mode = "spin_spiral";
+    cmc_spiral_wavevector = [0.0, 0.0, 0.0];
+    cmc_spiral_axis = [0.0, 0.0, 1.0];
+    cmc_spiral_propagation_direction = 2; // c planes
+
+The spiral axis is still required, finite, nonzero, and normalised internally
+at :math:`Q=0`, even though it has no numerical effect when every phase is
+zero.
 
 .. describe:: cmc_constraint_tolerance = 1e-6
 
@@ -210,10 +263,92 @@ The size of the angle is controlled by  :code:`move_angle_sigma`.
 
 .. describe:: move_angle_sigma = 0.5
 
-The size of :math:`\sigma` in :code:`move_fraction_angle`.
+The initial dimensionless size :math:`\sigma` in
+:code:`move_fraction_angle`. It controls the angular extent of the proposal
+but is not itself an angle in degrees or radians.
 
 .. math::
 	  (S_x, S_y, S_z) \rightarrow (S_x, S_y, S_z) + \sigma(\sin\theta\cos\phi, \sin\theta\sin\phi, \cos\theta) \quad \mathrm{where}\quad \theta\sim[0,\pi],\phi\sim[0,2\pi)
+
+Adaptive angle moves
+""""""""""""""""""""
+
+Angle-move adaptation is disabled by default. Enable it with a nested block:
+
+.. code-block:: cfg
+
+    move_angle_sigma = 0.01;
+    move_angle_adaptation = {
+      enabled = true;
+      target_acceptance = 0.10;
+      interval_steps = 100;
+      gain = 0.5;
+      min_sigma = 1.0e-6;
+      max_sigma = 0.1;
+      burn_in_steps = 10000;
+    };
+
+After each adaptation interval the solver uses only angle-move trials from
+that interval and updates in logarithmic space:
+
+.. math::
+
+    \log\sigma_{n+1} = \operatorname{clamp}\!\left(
+      \log\sigma_n + \gamma(a_n-a_{\mathrm{target}}),
+      \log\sigma_{\min}, \log\sigma_{\max}\right).
+
+Uniform and reflection moves do not contribute to :math:`a_n`. If no angle
+moves were attempted in an interval, the update is skipped. Adaptation
+intervals are independent of ``output_write_steps``.
+
+.. describe:: move_angle_adaptation.enabled = false
+
+Enables adaptive tuning when ``true``. The other settings below are required
+when adaptation is enabled.
+
+.. describe:: move_angle_adaptation.target_acceptance
+
+Dimensionless target angle-move acceptance fraction. It must be finite and
+satisfy ``0 < target_acceptance < 1``.
+
+.. describe:: move_angle_adaptation.interval_steps
+
+Positive integer number of Monte Carlo steps between updates.
+
+.. describe:: move_angle_adaptation.gain
+
+Finite positive dimensionless gain :math:`\gamma` in the update equation.
+
+.. describe:: move_angle_adaptation.min_sigma
+
+Finite positive dimensionless lower bound for :math:`\sigma`.
+
+.. describe:: move_angle_adaptation.max_sigma
+
+Finite positive dimensionless upper bound for :math:`\sigma`. The bounds and
+initial value must satisfy
+``min_sigma <= move_angle_sigma <= max_sigma``.
+
+.. describe:: move_angle_adaptation.burn_in_steps
+
+Positive integer burn-in duration in Monte Carlo steps, no greater than
+``max_steps``. At nonzero temperature this setting is mandatory: adaptation
+uses only the burn-in samples and the proposal width is frozen before
+production sampling. A final partial interval is updated at the burn-in
+boundary before freezing.
+
+At zero temperature ``burn_in_steps`` is optional. If omitted, adaptation
+continues for the complete constrained minimisation; if present, it freezes at
+the specified boundary. Unrestricted zero-temperature adaptation is intended
+for minimisation, not equilibrium sampling. A runtime guard stops a run if its
+temperature changes from zero to nonzero while unrestricted adaptation is
+active.
+
+The solver logs every update, skipped interval, reached bound, and frozen
+production value. Adaptive counters and the current :math:`\sigma` are not
+serialised by the existing restart mechanism. A restarted process therefore
+begins again from the configured ``move_angle_sigma``; only the restored spin
+configuration is retained.
 
 .. describe:: move_fraction_reflection = 0.0
 

--- a/examples/constrained_monte_carlo/adaptive_zero_temperature.cfg
+++ b/examples/constrained_monte_carlo/adaptive_zero_temperature.cfg
@@ -1,0 +1,69 @@
+# Adaptive proposal width for a zero-temperature constrained minimisation.
+sim = {
+  seed = 123456;
+};
+
+solver = {
+  module = "monte-carlo-constrained-cpu";
+  max_steps = 10000;
+  output_write_steps = 1000;
+
+  cmc_constraint_mode = "global";
+  cmc_constraint_type = "magnetisation";
+  cmc_constraint_theta = 5.0;
+  cmc_constraint_phi = 0.0;
+
+  move_angle_sigma = 0.01;
+  move_angle_adaptation = {
+    enabled = true;
+    target_acceptance = 0.10;
+    interval_steps = 100;
+    gain = 0.5;
+    min_sigma = 1.0e-6;
+    max_sigma = 0.1;
+    # No burn_in_steps: adaptation continues throughout this T=0 run.
+  };
+};
+
+physics = {
+  module = "empty";
+  temperature = 0.0;
+};
+
+materials = (
+  {
+    name = "A";
+    moment = 1.0;
+    spin = [0.0, 0.0, 1.0];
+  },
+  {
+    name = "B";
+    moment = 1.0;
+    spin = [0.0, 0.0, 1.0];
+  }
+);
+
+unitcell = {
+  parameter = 3.0e-10;
+  basis = (
+    [1.0, 0.0, 0.0],
+    [0.0, 1.0, 0.0],
+    [0.0, 0.0, 1.0]
+  );
+  positions = (
+    ("A", [0.0, 0.0, 0.0]),
+    ("B", [0.5, 0.0, 0.0])
+  );
+};
+
+lattice = {
+  size = [8, 2, 1];
+  periodic = [true, true, true];
+};
+
+hamiltonians = (
+  {
+    module = "applied-field";
+    field = [0.0, 0.0, 1.0];
+  }
+);

--- a/examples/constrained_monte_carlo/q0_plane.cfg
+++ b/examples/constrained_monte_carlo/q0_plane.cfg
@@ -1,0 +1,61 @@
+# Plane-constrained Q=0 reference normal to the lattice a direction.
+sim = {
+  seed = 123456;
+};
+
+solver = {
+  module = "monte-carlo-constrained-cpu";
+  max_steps = 1000;
+  output_write_steps = 100;
+
+  cmc_constraint_mode = "spin_spiral";
+  cmc_constraint_type = "magnetisation";
+  cmc_constraint_theta = 5.0;
+  cmc_constraint_phi = 0.0;
+  cmc_spiral_wavevector = [0.0, 0.0, 0.0];
+  cmc_spiral_axis = [0.0, 0.0, 1.0];
+  cmc_spiral_propagation_direction = 0;
+};
+
+physics = {
+  module = "empty";
+  temperature = 0.0;
+};
+
+materials = (
+  {
+    name = "A";
+    moment = 1.0;
+    spin = [0.0, 0.0, 1.0];
+  },
+  {
+    name = "B";
+    moment = 1.0;
+    spin = [0.0, 0.0, 1.0];
+  }
+);
+
+unitcell = {
+  parameter = 3.0e-10;
+  basis = (
+    [1.0, 0.0, 0.0],
+    [0.0, 1.0, 0.0],
+    [0.0, 0.0, 1.0]
+  );
+  positions = (
+    ("A", [0.0, 0.0, 0.0]),
+    ("B", [0.5, 0.0, 0.0])
+  );
+};
+
+lattice = {
+  size = [8, 2, 1];
+  periodic = [true, true, true];
+};
+
+hamiltonians = (
+  {
+    module = "applied-field";
+    field = [0.0, 0.0, 1.0];
+  }
+);

--- a/src/jams/containers/vec3.h
+++ b/src/jams/containers/vec3.h
@@ -40,6 +40,15 @@ inline constexpr bool vec_dot_is_zero(const T& value) {
 
 } // namespace detail
 
+/// Returns true if every component of a floating-point Vec is finite.
+template <typename T, std::size_t N>
+inline std::enable_if_t<std::is_floating_point_v<T>, bool>
+is_finite(const jams::Vec<T, N>& vector) {
+  return std::all_of(
+      vector.begin(), vector.end(),
+      [](const T value) { return std::isfinite(value); });
+}
+
 /// Returns the fused-multiply-add operation elementwise on the vectors a,b and c.
 /// x_k = (a_k * b_k) + c_k
 template <typename T1>

--- a/src/jams/interface/config.cc
+++ b/src/jams/interface/config.cc
@@ -8,6 +8,17 @@
 
 #include "config.h"
 
+void jams::require_settings(
+    const libconfig::Setting& setting,
+    const std::initializer_list<std::string_view> names,
+    const std::string_view error_message) {
+  for (const auto name : names) {
+    if (!setting.exists(std::string(name))) {
+      throw jams::ConfigException(setting, name, error_message);
+    }
+  }
+}
+
 void config_patch_simple(libconfig::Setting& orig, const libconfig::Setting& patch);
 void config_patch_element(libconfig::Setting& orig, const libconfig::Setting& patch);
 void config_patch_aggregate(libconfig::Setting& orig, const libconfig::Setting& patch);

--- a/src/jams/interface/config.h
+++ b/src/jams/interface/config.h
@@ -226,6 +226,13 @@ struct config_required_impl<InteractionFileFormat, void> {
       }
     }
 
+    // Throws for the first named setting that does not exist. The setting name
+    // is followed by the caller-provided error message.
+    void require_settings(
+        const libconfig::Setting& setting,
+        std::initializer_list<std::string_view> names,
+        std::string_view error_message);
+
     // Returns true if the setting is an integer type
     inline bool is_integer_setting(const libconfig::Setting& setting)
     {
@@ -283,6 +290,29 @@ struct config_required_impl<InteractionFileFormat, void> {
       }
 
       return int(setting);
+    }
+
+    // Returns an integer setting value within the inclusive range [minimum, maximum].
+    inline int read_integer_in_range(
+        const libconfig::Setting& setting,
+        const char* name,
+        const int minimum,
+        const int maximum)
+    {
+      if (!is_integer_setting(setting)) {
+        throw jams::ConfigException(setting, name, " must be an integer");
+      }
+
+      const auto value = setting.getType() == libconfig::Setting::TypeInt64
+          ? static_cast<int64_t>(setting)
+          : static_cast<int64_t>(int(setting));
+      if (value < minimum || value > maximum) {
+        throw jams::ConfigException(
+            setting, name, " must be an integer in the range ", minimum,
+            " to ", maximum);
+      }
+
+      return static_cast<int>(value);
     }
 
     // Returns a numeric setting value converted to T.

--- a/src/jams/solvers/cpu_monte_carlo_constrained.cc
+++ b/src/jams/solvers/cpu_monte_carlo_constrained.cc
@@ -1,6 +1,7 @@
 // Copyright 2014 Joseph Barker. All rights reserved.
 #include <cmath>
 #include <iomanip>
+#include <limits>
 #include <map>
 #include <sstream>
 
@@ -30,12 +31,6 @@ namespace {
       // this matches the mapping expected for atan2 but avoids the ambiguity
       // of -180.0 == 180.0 which can cause issues for rotation matricies
       return (x = fmod(x + 360.0, 360.0)) > 180.0 ? x - 360.0 : x;
-    }
-
-    bool is_finite(const jams::Vec<double, 3>& vector) {
-      return std::isfinite(vector[0])
-          && std::isfinite(vector[1])
-          && std::isfinite(vector[2]);
     }
 
     jams::Mat<double, 3, 3> rotation_to_z(const jams::Vec<double, 3>& direction) {
@@ -74,11 +69,15 @@ void ConstrainedMCSolver::initialize(const libconfig::Setting& settings) {
 
   const bool has_spiral_wavevector = settings.exists("cmc_spiral_wavevector");
   const bool has_spiral_axis = settings.exists("cmc_spiral_axis");
+  const bool has_spiral_propagation_direction =
+      settings.exists("cmc_spiral_propagation_direction");
   if (constraint_mode_ == ConstraintMode::Global
-      && (has_spiral_wavevector || has_spiral_axis)) {
+      && (has_spiral_wavevector || has_spiral_axis
+          || has_spiral_propagation_direction)) {
     throw jams::ConfigException(
         settings,
-        "cmc_spiral_wavevector and cmc_spiral_axis are only valid when "
+        "cmc_spiral_wavevector, cmc_spiral_axis, and "
+        "cmc_spiral_propagation_direction are only valid when "
         "cmc_constraint_mode is 'spin_spiral'");
   }
   if (constraint_mode_ == ConstraintMode::SpinSpiral
@@ -132,6 +131,8 @@ void ConstrainedMCSolver::initialize(const libconfig::Setting& settings) {
     move_fraction_reflection_  /= move_fraction_sum;
   }
 
+  initialize_move_angle_adaptation(settings);
+
   constraint_transformations_.assign(globals::num_spins, kIdentityMat3);
   for (int i = 0; i < globals::num_spins; ++i) {
     if (constraint_type_ == ConstraintType::MaterialTransform) {
@@ -156,32 +157,174 @@ void ConstrainedMCSolver::initialize(const libconfig::Setting& settings) {
   validate_constraint();
 }
 
+void ConstrainedMCSolver::initialize_move_angle_adaptation(
+    const libconfig::Setting& settings) {
+  if (!settings.exists("move_angle_adaptation")) {
+    return;
+  }
+
+  const auto& adaptation = settings["move_angle_adaptation"];
+  if (!adaptation.isGroup()) {
+    throw jams::ConfigException(
+        adaptation, "move_angle_adaptation must be a group");
+  }
+
+  if (adaptation.exists("enabled")) {
+    if (adaptation["enabled"].getType() != libconfig::Setting::TypeBoolean) {
+      throw jams::ConfigException(
+          adaptation["enabled"], "move_angle_adaptation.enabled must be boolean");
+    }
+    move_angle_adaptation_enabled_ = bool(adaptation["enabled"]);
+  }
+  if (!move_angle_adaptation_enabled_) {
+    return;
+  }
+
+  jams::require_settings(
+      adaptation,
+      {"target_acceptance", "interval_steps", "gain", "min_sigma", "max_sigma"},
+      " is required when move_angle_adaptation.enabled = true");
+
+  move_angle_target_acceptance_ = jams::read_numeric_setting<double>(
+      adaptation["target_acceptance"], "move_angle_adaptation.target_acceptance");
+  if (!std::isfinite(move_angle_target_acceptance_)
+      || move_angle_target_acceptance_ <= 0.0
+      || move_angle_target_acceptance_ >= 1.0) {
+    throw jams::ConfigException(
+        adaptation["target_acceptance"],
+        "move_angle_adaptation.target_acceptance must be finite and in the range 0 < target_acceptance < 1");
+  }
+
+  move_angle_adaptation_interval_steps_ = jams::read_integer_in_range(
+      adaptation["interval_steps"], "move_angle_adaptation.interval_steps",
+      1, std::numeric_limits<int>::max());
+
+  move_angle_adaptation_gain_ = jams::read_numeric_setting<double>(
+      adaptation["gain"], "move_angle_adaptation.gain");
+  if (!std::isfinite(move_angle_adaptation_gain_)
+      || move_angle_adaptation_gain_ <= 0.0) {
+    throw jams::ConfigException(
+        adaptation["gain"],
+        "move_angle_adaptation.gain must be finite and positive");
+  }
+
+  move_angle_min_sigma_ = jams::read_numeric_setting<double>(
+      adaptation["min_sigma"], "move_angle_adaptation.min_sigma");
+  if (!std::isfinite(move_angle_min_sigma_) || move_angle_min_sigma_ <= 0.0) {
+    throw jams::ConfigException(
+        adaptation["min_sigma"],
+        "move_angle_adaptation.min_sigma must be finite and positive");
+  }
+
+  move_angle_max_sigma_ = jams::read_numeric_setting<double>(
+      adaptation["max_sigma"], "move_angle_adaptation.max_sigma");
+  if (!std::isfinite(move_angle_max_sigma_) || move_angle_max_sigma_ <= 0.0) {
+    throw jams::ConfigException(
+        adaptation["max_sigma"],
+        "move_angle_adaptation.max_sigma must be finite and positive");
+  }
+  if (move_angle_min_sigma_ > move_angle_max_sigma_) {
+    throw jams::ConfigException(
+        adaptation["max_sigma"],
+        "move_angle_adaptation bounds must satisfy min_sigma <= max_sigma");
+  }
+  if (!std::isfinite(move_angle_sigma_)
+      || move_angle_sigma_ < move_angle_min_sigma_
+      || move_angle_sigma_ > move_angle_max_sigma_) {
+    throw jams::ConfigException(
+        settings,
+        "move_angle_sigma must be finite and satisfy move_angle_adaptation.min_sigma <= move_angle_sigma <= move_angle_adaptation.max_sigma");
+  }
+
+  if (adaptation.exists("burn_in_steps")) {
+    const auto burn_in_steps = jams::read_integer_in_range(
+        adaptation["burn_in_steps"], "move_angle_adaptation.burn_in_steps",
+        1, std::numeric_limits<int>::max());
+    if (burn_in_steps > max_steps_) {
+      throw jams::ConfigException(
+          adaptation["burn_in_steps"],
+          "move_angle_adaptation.burn_in_steps must be less than or equal to max_steps (",
+          max_steps_, ")");
+    }
+    move_angle_burn_in_steps_ = burn_in_steps;
+  }
+
+  if (!(move_fraction_angle_ > 0.0)) {
+    throw jams::ConfigException(
+        adaptation,
+        "move_angle_adaptation cannot be enabled when move_fraction_angle is zero");
+  }
+
+  if (!move_angle_burn_in_steps_.has_value()
+      && globals::config != nullptr
+      && globals::config->exists("physics.temperature")) {
+    const auto configured_temperature = jams::read_numeric_setting<double>(
+        globals::config->lookup("physics.temperature"), "physics.temperature");
+    if (configured_temperature != 0.0) {
+      throw jams::ConfigException(
+          adaptation,
+          "move_angle_adaptation.burn_in_steps is required when the simulation temperature is nonzero");
+    }
+  }
+}
+
 void ConstrainedMCSolver::initialize_spin_spiral(const libconfig::Setting& settings) {
   spiral_wavevector_ = jams::read_vec_setting<double, 3>(
       settings["cmc_spiral_wavevector"], "cmc_spiral_wavevector");
   spiral_axis_ = jams::read_vec_setting<double, 3>(
       settings["cmc_spiral_axis"], "cmc_spiral_axis");
 
-  if (!is_finite(spiral_wavevector_)) {
+  if (!jams::is_finite(spiral_wavevector_)) {
     throw jams::ConfigException(
         settings["cmc_spiral_wavevector"],
         "cmc_spiral_wavevector components must be finite");
   }
 
   int nonzero_wavevector_components = 0;
+  int inferred_propagation_direction = -1;
   for (auto direction = 0; direction < 3; ++direction) {
     if (spiral_wavevector_[direction] != 0.0) {
       ++nonzero_wavevector_components;
-      spiral_propagation_direction_ = direction;
+      inferred_propagation_direction = direction;
     }
   }
-  if (nonzero_wavevector_components != 1) {
+  if (nonzero_wavevector_components > 1) {
     throw jams::ConfigException(
         settings["cmc_spiral_wavevector"],
-        "cmc_spiral_wavevector must have exactly one non-zero component");
+        "cmc_spiral_wavevector must have at most one non-zero component");
   }
 
-  if (!is_finite(spiral_axis_)) {
+  const bool has_explicit_propagation_direction =
+      settings.exists("cmc_spiral_propagation_direction");
+  int explicit_propagation_direction = -1;
+  if (has_explicit_propagation_direction) {
+    const auto& direction_setting = settings["cmc_spiral_propagation_direction"];
+    explicit_propagation_direction = jams::read_integer_in_range(
+        direction_setting, "cmc_spiral_propagation_direction", 0, 2);
+  }
+
+  zero_wavevector_plane_constraint_ = nonzero_wavevector_components == 0;
+  if (zero_wavevector_plane_constraint_) {
+    if (!has_explicit_propagation_direction) {
+      throw jams::ConfigException(
+          settings["cmc_spiral_wavevector"],
+          "a zero cmc_spiral_wavevector requires "
+          "cmc_spiral_propagation_direction = 0, 1, or 2");
+    }
+    spiral_propagation_direction_ = explicit_propagation_direction;
+  } else {
+    spiral_propagation_direction_ = inferred_propagation_direction;
+    if (has_explicit_propagation_direction
+        && explicit_propagation_direction != inferred_propagation_direction) {
+      throw jams::ConfigException(
+          settings["cmc_spiral_propagation_direction"],
+          "cmc_spiral_propagation_direction = ", explicit_propagation_direction,
+          " conflicts with non-zero cmc_spiral_wavevector component ",
+          inferred_propagation_direction);
+    }
+  }
+
+  if (!jams::is_finite(spiral_axis_)) {
     throw jams::ConfigException(
         settings["cmc_spiral_axis"],
         "cmc_spiral_axis components must be finite");
@@ -263,6 +406,10 @@ void ConstrainedMCSolver::run() {
   // energy or with a Boltzmann thermal weighting.
   std::uniform_real_distribution<> uniform_distribution;
 
+  if (is_unrestricted_move_angle_adaptation_active()) {
+    validate_move_angle_adaptation_temperature(physics_module_->temperature());
+  }
+
   jams::montecarlo::MonteCarloUniformMove<jams::RandomGeneratorType> uniform_move(&jams::instance().random_generator());
   jams::montecarlo::MonteCarloAngleMove<jams::RandomGeneratorType>   angle_move(&jams::instance().random_generator(), move_angle_sigma_);
   jams::montecarlo::MonteCarloReflectionMove           reflection_move;
@@ -272,8 +419,15 @@ void ConstrainedMCSolver::run() {
     move_running_acceptance_count_uniform_ += AsselinAlgorithm(uniform_move);
     run_count_uniform_++;
   } else if (uniform_random_number < (move_fraction_uniform_ + move_fraction_angle_)) {
-    move_running_acceptance_count_angle_ += AsselinAlgorithm(angle_move);
+    unsigned attempted_angle_moves = 0;
+    const auto accepted_angle_moves = AsselinAlgorithm(
+        angle_move, &attempted_angle_moves);
+    move_running_acceptance_count_angle_ += accepted_angle_moves;
     run_count_angle_++;
+    if (move_angle_adaptation_enabled_ && !move_angle_adaptation_frozen_) {
+      move_angle_adaptation_attempted_ += attempted_angle_moves;
+      move_angle_adaptation_accepted_ += accepted_angle_moves;
+    }
   } else {
     move_running_acceptance_count_reflection_ += AsselinAlgorithm(reflection_move);
     run_count_reflection_++;
@@ -281,6 +435,8 @@ void ConstrainedMCSolver::run() {
 
   iteration_++;
   time_ = iteration_;
+
+  update_move_angle_adaptation(std::cout);
 
   if (iteration_ % output_write_steps_ == 0) {
     validate_constraint();
@@ -291,6 +447,86 @@ void ConstrainedMCSolver::run() {
   }
 }
 
+bool ConstrainedMCSolver::is_unrestricted_move_angle_adaptation_active() const {
+  return move_angle_adaptation_enabled_
+      && !move_angle_adaptation_frozen_
+      && !move_angle_burn_in_steps_.has_value();
+}
+
+void ConstrainedMCSolver::validate_move_angle_adaptation_temperature(
+    const double temperature) const {
+  if (is_unrestricted_move_angle_adaptation_active() && temperature != 0.0) {
+    throw std::runtime_error(
+        "ConstrainedMCSolver -- move_angle_adaptation.burn_in_steps is required "
+        "before unrestricted adaptation can run at nonzero temperature");
+  }
+}
+
+void ConstrainedMCSolver::update_move_angle_adaptation(std::ostream& os) {
+  if (!move_angle_adaptation_enabled_ || move_angle_adaptation_frozen_) {
+    return;
+  }
+
+  const bool interval_boundary =
+      iteration_ % move_angle_adaptation_interval_steps_ == 0;
+  const bool burn_in_boundary = move_angle_burn_in_steps_.has_value()
+      && iteration_ == *move_angle_burn_in_steps_;
+  if (!interval_boundary && !burn_in_boundary) {
+    return;
+  }
+
+  const auto original_flags = os.flags();
+  const auto original_precision = os.precision();
+  os << std::scientific << std::setprecision(8);
+
+  const double previous_sigma = move_angle_sigma_;
+  if (move_angle_adaptation_attempted_ == 0) {
+    os << "move_angle_adaptation: step " << iteration_
+       << ", attempted 0, accepted 0, acceptance n/a, previous sigma "
+       << previous_sigma << ", updated sigma " << move_angle_sigma_
+       << ", bound none, update skipped (no angle moves attempted)\n";
+  } else {
+    const double acceptance = static_cast<double>(move_angle_adaptation_accepted_)
+        / static_cast<double>(move_angle_adaptation_attempted_);
+    const double proposed_log_sigma = std::log(previous_sigma)
+        + move_angle_adaptation_gain_
+            * (acceptance - move_angle_target_acceptance_);
+    const double min_log_sigma = std::log(move_angle_min_sigma_);
+    const double max_log_sigma = std::log(move_angle_max_sigma_);
+
+    const char* bound = "none";
+    if (proposed_log_sigma <= min_log_sigma) {
+      move_angle_sigma_ = move_angle_min_sigma_;
+      bound = "minimum";
+    } else if (proposed_log_sigma >= max_log_sigma) {
+      move_angle_sigma_ = move_angle_max_sigma_;
+      bound = "maximum";
+    } else {
+      move_angle_sigma_ = std::exp(proposed_log_sigma);
+    }
+
+    os << "move_angle_adaptation: step " << iteration_
+       << ", attempted " << move_angle_adaptation_attempted_
+       << ", accepted " << move_angle_adaptation_accepted_
+       << ", acceptance " << acceptance
+       << ", previous sigma " << previous_sigma
+       << ", updated sigma " << move_angle_sigma_
+       << ", bound " << bound << "\n";
+  }
+
+  move_angle_adaptation_attempted_ = 0;
+  move_angle_adaptation_accepted_ = 0;
+
+  if (burn_in_boundary) {
+    move_angle_adaptation_frozen_ = true;
+    os << "move_angle_adaptation: burn-in complete at step " << iteration_
+       << "; frozen production sigma " << move_angle_sigma_ << "\n";
+  }
+
+  os.flags(original_flags);
+  os.precision(original_precision);
+}
+
 std::vector<jams::output::ColDef> ConstrainedMCSolver::monitor_coordinate_columns() const {
   return {{"step", "steps", jams::output::ColFmt::Integer}};
 }
@@ -299,7 +535,9 @@ void ConstrainedMCSolver::append_monitor_coordinates(std::vector<double>& values
   values.push_back(iteration());
 }
 
-unsigned ConstrainedMCSolver::AsselinAlgorithm(const std::function<jams::Vec<double, 3>(jams::Vec<double, 3>)>& trial_spin_move) {
+unsigned ConstrainedMCSolver::AsselinAlgorithm(
+    const std::function<jams::Vec<double, 3>(jams::Vec<double, 3>)>& trial_spin_move,
+    unsigned* moves_attempted) {
   std::uniform_real_distribution<> uniform_distribution;
 
   const double temperature = physics_module_->temperature();
@@ -335,6 +573,9 @@ unsigned ConstrainedMCSolver::AsselinAlgorithm(const std::function<jams::Vec<dou
     jams::Vec<double, 3> s1_initial_rotated = rotate_cartesian_to_constraint(s1, s1_initial);
 
     jams::Vec<double, 3> s1_trial           = trial_spin_move(s1_initial);
+    if (moves_attempted != nullptr) {
+      ++(*moves_attempted);
+    }
     jams::Vec<double, 3> s1_trial_rotated   = rotate_cartesian_to_constraint(s1, s1_trial);
 
     jams::Vec<double, 3> s2_initial         = jams::montecarlo::get_spin(s2);
@@ -532,6 +773,8 @@ void ConstrainedMCSolver::output_initialization_info(std::ostream &os) {
      << constraint_vector_[2] << "\n";
   if (constraint_mode_ == ConstraintMode::SpinSpiral) {
     os << "    spiral wavevector " << spiral_wavevector_ << " (cycles per unit cell)\n";
+    os << "    zero-wavevector plane constraint "
+       << (zero_wavevector_plane_constraint_ ? "yes" : "no") << "\n";
     os << "    spiral rotation axis " << spiral_axis_ << "\n";
     os << "    spiral propagation lattice direction " << spiral_propagation_direction_ << "\n";
     os << "    constrained planes " << constraint_planes_.size() << "\n";
@@ -544,6 +787,26 @@ void ConstrainedMCSolver::output_initialization_info(std::ostream &os) {
   os << "    move_fraction_angle " << move_fraction_angle_ << "\n";
   os << "    move_fraction_reflection " << move_fraction_reflection_ << "\n";
   os << "    move_angle_sigma " << move_angle_sigma_ << "\n";
+  os << "    move angle adaptation "
+     << (move_angle_adaptation_enabled_ ? "enabled" : "disabled") << "\n";
+  if (move_angle_adaptation_enabled_) {
+    const auto original_flags = os.flags();
+    const auto original_precision = os.precision();
+    os << std::scientific << std::setprecision(8);
+    os << "      initial sigma " << move_angle_sigma_ << "\n";
+    os << "      target acceptance " << move_angle_target_acceptance_ << "\n";
+    os << "      interval steps " << move_angle_adaptation_interval_steps_ << "\n";
+    os << "      gain " << move_angle_adaptation_gain_ << "\n";
+    os << "      sigma bounds " << move_angle_min_sigma_ << " "
+       << move_angle_max_sigma_ << "\n";
+    if (move_angle_burn_in_steps_.has_value()) {
+      os << "      burn-in steps " << *move_angle_burn_in_steps_ << "\n";
+    } else {
+      os << "      burn-in steps unrestricted (zero-temperature run only)\n";
+    }
+    os.flags(original_flags);
+    os.precision(original_precision);
+  }
   os << "    output_write_steps " << output_write_steps_ << "\n";
   if (constraint_mode_ == ConstraintMode::Global) {
     os << "    rotation matrix m -> mz\n";
@@ -639,7 +902,7 @@ void ConstrainedMCSolver::validate_constraint_vector(
     const std::string& description) const {
   const double order_parameter_norm = jams::norm(order_parameter);
 
-  if (!is_finite(order_parameter)
+  if (!jams::is_finite(order_parameter)
       || !std::isfinite(order_parameter_norm)
       || order_parameter_norm == 0.0) {
     std::stringstream ss;
@@ -719,7 +982,7 @@ void ConstrainedMCSolver::align_spins_to_constraint() const {
       const jams::Vec<double, 3>& vector,
       const std::string& description) {
     const double vector_norm = jams::norm(vector);
-    if (!is_finite(vector) || !std::isfinite(vector_norm) || vector_norm == 0.0) {
+    if (!jams::is_finite(vector) || !std::isfinite(vector_norm) || vector_norm == 0.0) {
       std::stringstream ss;
       ss << "ConstrainedMCSolver -- constraint direction is undefined for "
          << description << " because its vector is zero or non-finite ("

--- a/src/jams/solvers/cpu_monte_carlo_constrained.h
+++ b/src/jams/solvers/cpu_monte_carlo_constrained.h
@@ -5,6 +5,7 @@
 
 #include <random>
 #include <fstream>
+#include <optional>
 #include <vector>
 
 #include <jams/core/types.h>
@@ -31,6 +32,8 @@ class ConstrainedMCSolver : public Solver {
   std::string name() const override { return "monte-carlo-constrained-cpu"; }
 
  private:
+    friend class ConstrainedMCSolverConstraintTest;
+
     enum class ConstraintType {
       Magnetisation,
       MaterialTransform
@@ -57,6 +60,10 @@ class ConstrainedMCSolver : public Solver {
     const char* constraint_mode_name() const;
 
     void initialize_spin_spiral(const libconfig::Setting& settings);
+    void initialize_move_angle_adaptation(const libconfig::Setting& settings);
+    bool is_unrestricted_move_angle_adaptation_active() const;
+    void update_move_angle_adaptation(std::ostream& os);
+    void validate_move_angle_adaptation_temperature(double temperature) const;
 
     void validate_angles() const;
     void validate_rotation_matricies() const;
@@ -72,7 +79,9 @@ class ConstrainedMCSolver : public Solver {
 
     void align_spins_to_constraint() const;
 
-    unsigned AsselinAlgorithm(const std::function<jams::Vec<double, 3>(jams::Vec<double, 3>)>&  trial_spin_move);
+    unsigned AsselinAlgorithm(
+        const std::function<jams::Vec<double, 3>(jams::Vec<double, 3>)>& trial_spin_move,
+        unsigned* moves_attempted = nullptr);
 
     jams::Vec<double, 3>     spin_to_order_parameter(const int &i, const jams::Vec<double, 3> &spin) const;
     jams::Vec<double, 3>     order_parameter_to_spin(const int &i, const jams::Vec<double, 3> &spin) const;
@@ -107,6 +116,7 @@ class ConstrainedMCSolver : public Solver {
     jams::Vec<double, 3> spiral_wavevector_ = {{0.0, 0.0, 0.0}};
     jams::Vec<double, 3> spiral_axis_ = {{0.0, 0.0, 1.0}};
     int spiral_propagation_direction_ = -1;
+    bool zero_wavevector_plane_constraint_ = false;
     std::vector<ConstraintPlane> constraint_planes_;
     std::vector<int> spin_constraint_group_;
 
@@ -117,6 +127,17 @@ class ConstrainedMCSolver : public Solver {
     double move_fraction_reflection_  = 0.0;
 
     double move_angle_sigma_ = 0.5;
+
+    bool move_angle_adaptation_enabled_ = false;
+    bool move_angle_adaptation_frozen_ = false;
+    double move_angle_target_acceptance_ = 0.0;
+    int move_angle_adaptation_interval_steps_ = 0;
+    double move_angle_adaptation_gain_ = 0.0;
+    double move_angle_min_sigma_ = 0.0;
+    double move_angle_max_sigma_ = 0.0;
+    std::optional<int> move_angle_burn_in_steps_;
+    unsigned long long move_angle_adaptation_attempted_ = 0;
+    unsigned long long move_angle_adaptation_accepted_ = 0;
 
     unsigned run_count_uniform_    = 0;
     unsigned run_count_angle_      = 0;

--- a/src/jams/test/containers/test_vec3.h
+++ b/src/jams/test/containers/test_vec3.h
@@ -6,6 +6,7 @@
 #include <cmath>
 #include <complex>
 #include <cstdint>
+#include <limits>
 #include <numeric>
 #include <type_traits>
 #include <utility>
@@ -70,6 +71,15 @@ TEST(VecTest, SupportsGenericDimensionArithmetic) {
   EXPECT_EQ(jams::dot(a, b), 70);
   EXPECT_EQ(jams::sum(a), 10);
   EXPECT_EQ(jams::product(a), 24);
+}
+
+TEST(VecTest, IsFiniteSupportsFloatingPointVecsOfAnyLength) {
+  EXPECT_TRUE(jams::is_finite(jams::Vec<float, 2>{1.0f, -2.0f}));
+  EXPECT_TRUE(jams::is_finite(jams::Vec<double, 4>{1.0, 2.0, 3.0, 4.0}));
+  EXPECT_FALSE(jams::is_finite(jams::Vec<double, 4>{
+      1.0, std::numeric_limits<double>::infinity(), 3.0, 4.0}));
+  EXPECT_FALSE(jams::is_finite(jams::Vec<float, 2>{
+      std::numeric_limits<float>::quiet_NaN(), 1.0f}));
 }
 
 TEST(Vec3Test, AngleUsesBothVectorNorms) {

--- a/src/jams/test/solvers/test_cpu_monte_carlo_constrained.h
+++ b/src/jams/test/solvers/test_cpu_monte_carlo_constrained.h
@@ -283,20 +283,165 @@ class ConstrainedMCSolverConstraintTest : public ::testing::Test {
 
   std::unique_ptr<ConstrainedMCSolver> make_programmatic_spiral_solver(
       const jams::Vec<double, 3>& wavevector,
-      const jams::Vec<double, 3>& axis) {
+      const jams::Vec<double, 3>& axis,
+      const std::optional<int> propagation_direction = std::nullopt,
+      const jams::Vec<int, 3>& lattice_size = {4, 2, 1}) {
     globals::config = std::make_unique<libconfig::Config>();
     const auto config_text = constrained_mc_config(
         "magnetisation", 90.0, 0.0, true, "", std::nullopt, std::nullopt,
-        {4, 2, 1}, {true, true, true});
+        lattice_size, {true, true, true});
     globals::config->readString(config_text.c_str());
     auto& solver_settings = globals::config->lookup("solver");
     solver_settings.add("cmc_constraint_mode", libconfig::Setting::TypeString)
         = "spin_spiral";
     add_vec_setting(solver_settings, "cmc_spiral_wavevector", wavevector);
     add_vec_setting(solver_settings, "cmc_spiral_axis", axis);
+    if (propagation_direction.has_value()) {
+      solver_settings.add(
+          "cmc_spiral_propagation_direction", libconfig::Setting::TypeInt)
+          = *propagation_direction;
+    }
     globals::lattice = new Lattice();
     globals::lattice->init_from_config(*globals::config);
     return std::make_unique<ConstrainedMCSolver>(solver_settings);
+  }
+
+  std::unique_ptr<ConstrainedMCSolver> make_configured_solver(
+      const double temperature,
+      const std::function<void(libconfig::Setting&)>& configure_solver,
+      const bool register_physics = true) {
+    globals::config = std::make_unique<libconfig::Config>();
+    globals::config->readString(
+        constrained_mc_config("magnetisation", 90.0, 0.0, true).c_str());
+    globals::config->lookup("physics.temperature") = temperature;
+    auto& solver_settings = globals::config->lookup("solver");
+    configure_solver(solver_settings);
+    globals::lattice = new Lattice();
+    globals::lattice->init_from_config(*globals::config);
+    auto solver = std::make_unique<ConstrainedMCSolver>(solver_settings);
+    if (register_physics) {
+      solver->register_physics_module(
+          Physics::create(globals::config->lookup("physics")));
+    }
+    return solver;
+  }
+
+  void add_move_angle_adaptation(
+      libconfig::Setting& solver_settings,
+      const std::optional<double> target_acceptance = 0.1,
+      const std::optional<int> interval_steps = 10,
+      const std::optional<double> gain = 0.5,
+      const std::optional<double> min_sigma = 1.0e-6,
+      const std::optional<double> max_sigma = 0.1,
+      const std::optional<int> burn_in_steps = std::nullopt,
+      const bool enabled = true) {
+    auto& adaptation = solver_settings.add(
+        "move_angle_adaptation", libconfig::Setting::TypeGroup);
+    adaptation.add("enabled", libconfig::Setting::TypeBoolean) = enabled;
+    if (target_acceptance.has_value()) {
+      adaptation.add("target_acceptance", libconfig::Setting::TypeFloat)
+          = *target_acceptance;
+    }
+    if (interval_steps.has_value()) {
+      adaptation.add("interval_steps", libconfig::Setting::TypeInt)
+          = *interval_steps;
+    }
+    if (gain.has_value()) {
+      adaptation.add("gain", libconfig::Setting::TypeFloat) = *gain;
+    }
+    if (min_sigma.has_value()) {
+      adaptation.add("min_sigma", libconfig::Setting::TypeFloat) = *min_sigma;
+    }
+    if (max_sigma.has_value()) {
+      adaptation.add("max_sigma", libconfig::Setting::TypeFloat) = *max_sigma;
+    }
+    if (burn_in_steps.has_value()) {
+      adaptation.add("burn_in_steps", libconfig::Setting::TypeInt)
+          = *burn_in_steps;
+    }
+  }
+
+  std::string perform_adaptation_update(
+      ConstrainedMCSolver& solver,
+      const int step,
+      const unsigned long long attempted,
+      const unsigned long long accepted) {
+    solver.iteration_ = step;
+    solver.move_angle_adaptation_attempted_ = attempted;
+    solver.move_angle_adaptation_accepted_ = accepted;
+    std::ostringstream output;
+    solver.update_move_angle_adaptation(output);
+    return output.str();
+  }
+
+  std::size_t constraint_plane_count(const ConstrainedMCSolver& solver) const {
+    return solver.constraint_planes_.size();
+  }
+
+  int constraint_plane_coordinate(
+      const ConstrainedMCSolver& solver, const std::size_t plane) const {
+    return solver.constraint_planes_[plane].coordinate;
+  }
+
+  const std::vector<int>& constraint_plane_spins(
+      const ConstrainedMCSolver& solver, const std::size_t plane) const {
+    return solver.constraint_planes_[plane].spins;
+  }
+
+  jams::Vec<double, 3> constraint_plane_target(
+      const ConstrainedMCSolver& solver, const std::size_t plane) const {
+    return solver.constraint_planes_[plane].target_direction;
+  }
+
+  int spin_constraint_group(
+      const ConstrainedMCSolver& solver, const int spin) const {
+    return solver.spin_constraint_group_[spin];
+  }
+
+  double move_angle_sigma(const ConstrainedMCSolver& solver) const {
+    return solver.move_angle_sigma_;
+  }
+
+  bool move_angle_adaptation_frozen(const ConstrainedMCSolver& solver) const {
+    return solver.move_angle_adaptation_frozen_;
+  }
+
+  std::pair<unsigned long long, unsigned long long> adaptation_counters(
+      const ConstrainedMCSolver& solver) const {
+    return {solver.move_angle_adaptation_attempted_,
+            solver.move_angle_adaptation_accepted_};
+  }
+
+  void set_non_angle_statistics(
+      ConstrainedMCSolver& solver,
+      const unsigned long long uniform,
+      const unsigned long long reflection) {
+    solver.move_running_acceptance_count_uniform_ = uniform;
+    solver.move_running_acceptance_count_reflection_ = reflection;
+  }
+
+  void set_solver_temperature(ConstrainedMCSolver& solver, const double temperature) {
+    solver.physics_module_->set_temperature(temperature);
+  }
+
+  std::string initialization_output(ConstrainedMCSolver& solver) {
+    std::ostringstream output;
+    solver.output_initialization_info(output);
+    return output.str();
+  }
+
+  std::vector<jams::Vec<double, 3>> run_seeded_solver(
+      ConstrainedMCSolver& solver,
+      const unsigned seed,
+      const int steps) {
+    jams::instance().random_generator().seed(seed);
+    std::vector<jams::Vec<double, 3>> trajectory;
+    trajectory.reserve(steps);
+    for (auto step = 0; step < steps; ++step) {
+      solver.run();
+      trajectory.push_back(jams::montecarlo::get_spin(0));
+    }
+    return trajectory;
   }
 
   void exercise_pair_moves(const std::string& constraint_type, const bool transformed) {
@@ -430,20 +575,149 @@ TEST_F(ConstrainedMCSolverConstraintTest, GlobalModeRejectsSpiralSettings) {
 }
 
 TEST_F(ConstrainedMCSolverConstraintTest, RejectsInvalidSpinSpiralVectors) {
-  for (const auto wavevector : {
-           jams::Vec<double, 3>{0.0, 0.0, 0.0},
-           jams::Vec<double, 3>{0.25, 0.25, 0.0}}) {
-    SCOPED_TRACE(wavevector);
+  EXPECT_THROW(
+      make_spiral_solver(
+          "magnetisation", 90.0, 0.0, true,
+          {0.25, 0.25, 0.0}, {0.0, 0.0, 1.0}),
+      jams::ConfigException);
+
+  reset_constrained_mc_globals();
+  EXPECT_THROW(
+      make_spiral_solver(
+          "magnetisation", 90.0, 0.0, true, {0.25, 0.0, 0.0}, {0.0, 0.0, 0.0}),
+      jams::ConfigException);
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, ZeroWavevectorRequiresPropagationDirection) {
+  EXPECT_THROW(
+      make_programmatic_spiral_solver(
+          {0.0, 0.0, 0.0}, {0.0, 0.0, 1.0}),
+      jams::ConfigException);
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, ZeroWavevectorAcceptsEveryPropagationDirection) {
+  const jams::Vec<int, 3> lattice_size = {2, 3, 4};
+  for (auto direction = 0; direction < 3; ++direction) {
+    SCOPED_TRACE(direction);
+    auto solver = make_programmatic_spiral_solver(
+        {0.0, 0.0, 0.0}, {0.0, 0.0, 2.0}, direction, lattice_size);
+
+    ASSERT_EQ(constraint_plane_count(*solver), lattice_size[direction]);
+    const auto spins_per_plane =
+        2 * lattice_size[(direction + 1) % 3]
+          * lattice_size[(direction + 2) % 3];
+    for (auto plane = 0; plane < constraint_plane_count(*solver); ++plane) {
+      const auto coordinate = constraint_plane_coordinate(*solver, plane);
+      const auto& spins = constraint_plane_spins(*solver, plane);
+      EXPECT_EQ(spins.size(), spins_per_plane);
+      for (const auto spin : spins) {
+        EXPECT_EQ(
+            globals::lattice->cell_offset(spin)[direction], coordinate);
+        EXPECT_EQ(spin_constraint_group(*solver, spin), plane);
+      }
+      expect_direction(
+          constraint_plane_target(*solver, plane), {1.0, 0.0, 0.0});
+    }
+
+    solver.reset();
+    reset_constrained_mc_globals();
+  }
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, ZeroWavevectorPartnersPreserveEveryPlaneConstraint) {
+  auto solver = make_programmatic_spiral_solver(
+      {0.0, 0.0, 0.0}, {0.0, 0.0, 1.0}, 0, {4, 2, 1});
+  solver->register_physics_module(
+      Physics::create(globals::config->lookup("physics")));
+
+  jams::instance().random_generator().seed(97531u);
+  for (auto step = 0; step < 128; ++step) {
+    ASSERT_NO_THROW(solver->run());
+  }
+
+  for (auto plane = 0; plane < 4; ++plane) {
+    expect_direction(
+        constrained_mc_plane_total(0, plane, false), {1.0, 0.0, 0.0});
+  }
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, ZeroWavevectorMatchesReciprocalLatticeVectorWorkaround) {
+  const auto run_case = [this](const double wavevector_component) {
+    auto solver = make_programmatic_spiral_solver(
+        {wavevector_component, 0.0, 0.0}, {0.0, 0.0, 1.0}, 0, {4, 2, 1});
+    solver->register_physics_module(
+        Physics::create(globals::config->lookup("physics")));
+    jams::instance().random_generator().seed(86420u);
+    for (auto step = 0; step < 64; ++step) {
+      solver->run();
+    }
+    std::vector<jams::Vec<double, 3>> spins(globals::num_spins);
+    for (auto spin = 0; spin < globals::num_spins; ++spin) {
+      spins[spin] = jams::montecarlo::get_spin(spin);
+    }
+    solver.reset();
+    reset_constrained_mc_globals();
+    return spins;
+  };
+
+  const auto zero_wavevector_spins = run_case(0.0);
+  const auto reciprocal_wavevector_spins = run_case(1.0);
+  ASSERT_EQ(zero_wavevector_spins.size(), reciprocal_wavevector_spins.size());
+  for (auto spin = 0; spin < zero_wavevector_spins.size(); ++spin) {
+    for (auto component = 0; component < 3; ++component) {
+      EXPECT_NEAR(
+          zero_wavevector_spins[spin][component],
+          reciprocal_wavevector_spins[spin][component], 1.0e-10);
+    }
+  }
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, NonzeroWavevectorAcceptsAbsentOrMatchingDirection) {
+  EXPECT_NO_THROW(make_programmatic_spiral_solver(
+      {0.0, 0.5, 0.0}, {0.0, 0.0, 1.0}));
+
+  reset_constrained_mc_globals();
+  EXPECT_NO_THROW(make_programmatic_spiral_solver(
+      {0.0, 0.5, 0.0}, {0.0, 0.0, 1.0}, 1));
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, NonzeroWavevectorRejectsConflictingDirection) {
+  EXPECT_THROW(
+      make_programmatic_spiral_solver(
+          {0.0, 0.5, 0.0}, {0.0, 0.0, 1.0}, 2),
+      jams::ConfigException);
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, RejectsInvalidPropagationDirections) {
+  for (const auto direction : {-1, 3}) {
+    SCOPED_TRACE(direction);
     EXPECT_THROW(
-        make_spiral_solver(
-            "magnetisation", 90.0, 0.0, true, wavevector, {0.0, 0.0, 1.0}),
+        make_programmatic_spiral_solver(
+            {0.0, 0.0, 0.0}, {0.0, 0.0, 1.0}, direction),
         jams::ConfigException);
     reset_constrained_mc_globals();
   }
 
   EXPECT_THROW(
-      make_spiral_solver(
-          "magnetisation", 90.0, 0.0, true, {0.25, 0.0, 0.0}, {0.0, 0.0, 0.0}),
+      make_configured_solver(0.0, [](libconfig::Setting& settings) {
+        settings.add("cmc_constraint_mode", libconfig::Setting::TypeString)
+            = "spin_spiral";
+        add_vec_setting(
+            settings, "cmc_spiral_wavevector", {0.0, 0.0, 0.0});
+        add_vec_setting(settings, "cmc_spiral_axis", {0.0, 0.0, 1.0});
+        settings.add(
+            "cmc_spiral_propagation_direction", libconfig::Setting::TypeFloat)
+            = 1.0;
+      }),
+      jams::ConfigException);
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, GlobalModeRejectsPropagationDirection) {
+  EXPECT_THROW(
+      make_configured_solver(0.0, [](libconfig::Setting& settings) {
+        settings.add(
+            "cmc_spiral_propagation_direction", libconfig::Setting::TypeInt) = 0;
+      }),
       jams::ConfigException);
 }
 
@@ -732,6 +1006,300 @@ TEST_F(ConstrainedMCSolverConstraintTest, PairMovesPreserveSpinSpiralPlaneMagnet
 
 TEST_F(ConstrainedMCSolverConstraintTest, PairMovesPreserveSpinSpiralPlaneTransformedMoments) {
   exercise_spiral_pair_moves("material_transform", true);
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, DisabledAdaptationPreservesSeededTrajectory) {
+  const auto run_case = [this](const bool add_disabled_block) {
+    auto solver = make_configured_solver(
+        1000000.0, [this, add_disabled_block](libconfig::Setting& settings) {
+          settings["output_write_steps"] = 7;
+          if (add_disabled_block) {
+            add_move_angle_adaptation(
+                settings, std::nullopt, std::nullopt, std::nullopt,
+                std::nullopt, std::nullopt, std::nullopt, false);
+          }
+        });
+    const auto trajectory = run_seeded_solver(*solver, 112233u, 32);
+    solver.reset();
+    reset_constrained_mc_globals();
+    return trajectory;
+  };
+
+  const auto legacy_trajectory = run_case(false);
+  const auto disabled_trajectory = run_case(true);
+  ASSERT_EQ(legacy_trajectory.size(), disabled_trajectory.size());
+  for (auto step = 0; step < legacy_trajectory.size(); ++step) {
+    EXPECT_EQ(legacy_trajectory[step], disabled_trajectory[step]);
+  }
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, AdaptationRespondsToAngleAcceptance) {
+  auto make_adaptive_solver = [this] {
+    return make_configured_solver(0.0, [this](libconfig::Setting& settings) {
+      add_move_angle_adaptation(settings, 0.1, 10, 0.5, 1.0e-6, 0.1);
+    });
+  };
+
+  auto solver = make_adaptive_solver();
+  const auto initial_sigma = move_angle_sigma(*solver);
+  perform_adaptation_update(*solver, 10, 100, 0);
+  EXPECT_LT(move_angle_sigma(*solver), initial_sigma);
+
+  solver.reset();
+  reset_constrained_mc_globals();
+  solver = make_adaptive_solver();
+  perform_adaptation_update(*solver, 10, 100, 100);
+  EXPECT_GT(move_angle_sigma(*solver), initial_sigma);
+
+  solver.reset();
+  reset_constrained_mc_globals();
+  solver = make_adaptive_solver();
+  perform_adaptation_update(*solver, 10, 100, 10);
+  EXPECT_DOUBLE_EQ(move_angle_sigma(*solver), initial_sigma);
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, AdaptationClampsSigmaAtBothBounds) {
+  auto make_adaptive_solver = [this](const double target_acceptance) {
+    return make_configured_solver(0.0, [this, target_acceptance](libconfig::Setting& settings) {
+      add_move_angle_adaptation(
+          settings, target_acceptance, 10, 100.0, 0.01, 0.1);
+    });
+  };
+
+  auto solver = make_adaptive_solver(0.9);
+  const auto minimum_output = perform_adaptation_update(*solver, 10, 100, 0);
+  EXPECT_DOUBLE_EQ(move_angle_sigma(*solver), 0.01);
+  EXPECT_NE(minimum_output.find("bound minimum"), std::string::npos);
+
+  solver.reset();
+  reset_constrained_mc_globals();
+  solver = make_adaptive_solver(0.1);
+  const auto maximum_output = perform_adaptation_update(*solver, 10, 100, 100);
+  EXPECT_DOUBLE_EQ(move_angle_sigma(*solver), 0.1);
+  EXPECT_NE(maximum_output.find("bound maximum"), std::string::npos);
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, AdaptationUsesOnlyAngleMoveStatistics) {
+  auto solver = make_configured_solver(0.0, [this](libconfig::Setting& settings) {
+    add_move_angle_adaptation(settings, 0.5, 10, 1.0, 1.0e-6, 0.1);
+  });
+  const auto initial_sigma = move_angle_sigma(*solver);
+  set_non_angle_statistics(*solver, 1000000, 1000000);
+  perform_adaptation_update(*solver, 10, 100, 0);
+  EXPECT_LT(move_angle_sigma(*solver), initial_sigma);
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, AdaptationResetsItsIntervalCounters) {
+  auto solver = make_configured_solver(0.0, [this](libconfig::Setting& settings) {
+    add_move_angle_adaptation(settings, 0.1, 10, 0.5, 1.0e-6, 0.1);
+  });
+  perform_adaptation_update(*solver, 10, 100, 25);
+  EXPECT_EQ(adaptation_counters(*solver), std::make_pair(0ULL, 0ULL));
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, AdaptationSkipsIntervalsWithoutAngleMoves) {
+  auto solver = make_configured_solver(0.0, [this](libconfig::Setting& settings) {
+    add_move_angle_adaptation(settings, 0.1, 10, 0.5, 1.0e-6, 0.1);
+  });
+  const auto initial_sigma = move_angle_sigma(*solver);
+  const auto output = perform_adaptation_update(*solver, 10, 0, 0);
+  EXPECT_DOUBLE_EQ(move_angle_sigma(*solver), initial_sigma);
+  EXPECT_NE(output.find("update skipped (no angle moves attempted)"), std::string::npos);
+  EXPECT_EQ(adaptation_counters(*solver), std::make_pair(0ULL, 0ULL));
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, ZeroTemperatureAdaptationAllowsNoBurnIn) {
+  EXPECT_NO_THROW(make_configured_solver(0.0, [this](libconfig::Setting& settings) {
+    add_move_angle_adaptation(settings, 0.1, 10, 0.5, 1.0e-6, 0.1);
+  }));
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, OptionalZeroTemperatureBurnInFreezesSigma) {
+  auto solver = make_configured_solver(0.0, [this](libconfig::Setting& settings) {
+    settings["output_write_steps"] = 7;
+    add_move_angle_adaptation(settings, 0.1, 10, 0.5, 1.0e-6, 0.1, 3);
+  });
+  const auto initial_sigma = move_angle_sigma(*solver);
+  for (auto step = 0; step < 3; ++step) {
+    solver->run();
+  }
+  const auto frozen_sigma = move_angle_sigma(*solver);
+  EXPECT_LT(frozen_sigma, initial_sigma);
+  EXPECT_TRUE(move_angle_adaptation_frozen(*solver));
+  for (auto step = 0; step < 10; ++step) {
+    solver->run();
+    EXPECT_DOUBLE_EQ(move_angle_sigma(*solver), frozen_sigma);
+  }
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, NonzeroTemperatureAdaptationRequiresBurnIn) {
+  try {
+    auto solver = make_configured_solver(
+        300.0, [this](libconfig::Setting& settings) {
+          add_move_angle_adaptation(settings, 0.1, 10, 0.5, 1.0e-6, 0.1);
+        });
+    FAIL() << "expected missing finite-temperature burn-in to fail";
+  } catch (const jams::ConfigException& error) {
+    EXPECT_NE(
+        std::string(error.what()).find("move_angle_adaptation.burn_in_steps"),
+        std::string::npos);
+  }
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, FiniteTemperatureBurnInFreezesProductionSigma) {
+  auto solver = make_configured_solver(300.0, [this](libconfig::Setting& settings) {
+    settings["output_write_steps"] = 7;
+    add_move_angle_adaptation(settings, 0.1, 2, 0.5, 1.0e-6, 0.1, 3);
+  });
+  const auto initial_sigma = move_angle_sigma(*solver);
+  for (auto step = 0; step < 3; ++step) {
+    solver->run();
+  }
+  const auto frozen_sigma = move_angle_sigma(*solver);
+  EXPECT_NE(frozen_sigma, initial_sigma);
+  EXPECT_TRUE(move_angle_adaptation_frozen(*solver));
+  for (auto step = 0; step < 12; ++step) {
+    solver->run();
+    EXPECT_DOUBLE_EQ(move_angle_sigma(*solver), frozen_sigma);
+  }
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, UnrestrictedAdaptationGuardsTemperatureChanges) {
+  auto solver = make_configured_solver(0.0, [this](libconfig::Setting& settings) {
+    add_move_angle_adaptation(settings, 0.1, 10, 0.5, 1.0e-6, 0.1);
+  });
+  EXPECT_NO_THROW(solver->run());
+  set_solver_temperature(*solver, 1.0);
+  EXPECT_THROW(solver->run(), std::runtime_error);
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, AdaptationIntervalIsIndependentOfOutputInterval) {
+  auto solver = make_configured_solver(0.0, [this](libconfig::Setting& settings) {
+    settings["output_write_steps"] = 7;
+    add_move_angle_adaptation(settings, 0.1, 2, 0.5, 1.0e-6, 0.1);
+  });
+  const auto initial_sigma = move_angle_sigma(*solver);
+  solver->run();
+  EXPECT_DOUBLE_EQ(move_angle_sigma(*solver), initial_sigma);
+  solver->run();
+  EXPECT_LT(move_angle_sigma(*solver), initial_sigma);
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, RejectsInvalidAdaptationSettings) {
+  struct InvalidCase {
+    std::string setting;
+    std::function<void(libconfig::Setting&)> configure;
+  };
+  const std::vector<InvalidCase> invalid_cases = {
+      {"target_acceptance", [this](auto& settings) {
+         add_move_angle_adaptation(settings, 0.0, 10, 0.5, 1.0e-6, 0.1);
+       }},
+      {"interval_steps", [this](auto& settings) {
+         add_move_angle_adaptation(settings, 0.1, 0, 0.5, 1.0e-6, 0.1);
+       }},
+      {"gain", [this](auto& settings) {
+         add_move_angle_adaptation(settings, 0.1, 10, 0.0, 1.0e-6, 0.1);
+       }},
+      {"min_sigma", [this](auto& settings) {
+         add_move_angle_adaptation(settings, 0.1, 10, 0.5, 0.0, 0.1);
+       }},
+      {"max_sigma", [this](auto& settings) {
+         add_move_angle_adaptation(settings, 0.1, 10, 0.5, 0.1, 0.01);
+       }},
+      {"move_angle_sigma", [this](auto& settings) {
+         settings["move_angle_sigma"] = 0.2;
+         add_move_angle_adaptation(settings, 0.1, 10, 0.5, 1.0e-6, 0.1);
+       }},
+      {"burn_in_steps", [this](auto& settings) {
+         add_move_angle_adaptation(settings, 0.1, 10, 0.5, 1.0e-6, 0.1, 101);
+       }},
+  };
+
+  for (const auto& invalid_case : invalid_cases) {
+    SCOPED_TRACE(invalid_case.setting);
+    try {
+      auto solver = make_configured_solver(0.0, invalid_case.configure);
+      FAIL() << "expected invalid adaptation setting to fail";
+    } catch (const jams::ConfigException& error) {
+      EXPECT_NE(
+          std::string(error.what()).find(invalid_case.setting),
+          std::string::npos);
+    }
+    reset_constrained_mc_globals();
+  }
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, AdaptationRequiresEveryEnabledSetting) {
+  for (const auto& missing : {
+           std::string("target_acceptance"), std::string("interval_steps"),
+           std::string("gain"), std::string("min_sigma"), std::string("max_sigma")}) {
+    SCOPED_TRACE(missing);
+    try {
+      auto solver = make_configured_solver(
+          0.0, [this, &missing](libconfig::Setting& settings) {
+            add_move_angle_adaptation(
+                settings,
+                missing == "target_acceptance" ? std::nullopt
+                                                : std::optional<double>(0.1),
+                missing == "interval_steps" ? std::nullopt
+                                             : std::optional<int>(10),
+                missing == "gain" ? std::nullopt
+                                   : std::optional<double>(0.5),
+                missing == "min_sigma" ? std::nullopt
+                                        : std::optional<double>(1.0e-6),
+                missing == "max_sigma" ? std::nullopt
+                                        : std::optional<double>(0.1));
+          });
+      FAIL() << "expected missing adaptation setting to fail";
+    } catch (const jams::ConfigException& error) {
+      EXPECT_NE(std::string(error.what()).find(missing), std::string::npos);
+    }
+    reset_constrained_mc_globals();
+  }
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, AdaptationRejectsZeroAngleMoveFraction) {
+  EXPECT_THROW(
+      make_configured_solver(0.0, [this](libconfig::Setting& settings) {
+        settings.add("move_fraction_uniform", libconfig::Setting::TypeFloat) = 1.0;
+        settings.add("move_fraction_angle", libconfig::Setting::TypeFloat) = 0.0;
+        settings.add("move_fraction_reflection", libconfig::Setting::TypeFloat) = 0.0;
+        add_move_angle_adaptation(settings, 0.1, 10, 0.5, 1.0e-6, 0.1);
+      }),
+      jams::ConfigException);
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, AdaptationLogsInitialUpdatedBoundedAndFrozenStates) {
+  auto solver = make_configured_solver(0.0, [this](libconfig::Setting& settings) {
+    add_move_angle_adaptation(settings, 0.9, 10, 100.0, 0.01, 0.1, 10);
+  });
+  auto output = initialization_output(*solver);
+  output += perform_adaptation_update(*solver, 10, 100, 0);
+  EXPECT_NE(output.find("move angle adaptation enabled"), std::string::npos);
+  EXPECT_NE(output.find("initial sigma"), std::string::npos);
+  EXPECT_NE(output.find("attempted 100, accepted 0"), std::string::npos);
+  EXPECT_NE(output.find("bound minimum"), std::string::npos);
+  EXPECT_NE(output.find("frozen production sigma"), std::string::npos);
+}
+
+TEST_F(ConstrainedMCSolverConstraintTest, AdaptiveTrajectoriesAreSeedDeterministic) {
+  const auto run_case = [this] {
+    auto solver = make_configured_solver(300.0, [this](libconfig::Setting& settings) {
+      settings["output_write_steps"] = 7;
+      add_move_angle_adaptation(settings, 0.1, 2, 0.5, 1.0e-6, 0.1, 8);
+    });
+    jams::instance().random_generator().seed(445566u);
+    std::vector<double> sigmas;
+    for (auto step = 0; step < 12; ++step) {
+      solver->run();
+      sigmas.push_back(move_angle_sigma(*solver));
+    }
+    solver.reset();
+    reset_constrained_mc_globals();
+    return sigmas;
+  };
+
+  EXPECT_EQ(run_case(), run_case());
 }
 
 #endif  // JAMS_TEST_SOLVERS_TEST_CPU_MONTE_CARLO_CONSTRAINED_H

--- a/test/test_constrained_monte_carlo.py
+++ b/test/test_constrained_monte_carlo.py
@@ -1,0 +1,146 @@
+import re
+import subprocess
+import unittest
+
+import libconf
+
+from test.jams_integration_test import JamsIntegrationtest
+
+
+def constrained_mc_config(*, temperature, solver):
+    config = {
+        "sim": {"seed": 24680},
+        "materials": (
+            {"name": "A", "moment": 2.0, "spin": [1.0, 0.0, 0.0]},
+            {"name": "B", "moment": 1.0, "spin": [0.0, 1.0, 0.0]},
+        ),
+        "unitcell": {
+            "parameter": 3.0e-10,
+            "basis": (
+                [1.0, 0.0, 0.0],
+                [0.0, 1.0, 0.0],
+                [0.0, 0.0, 1.0],
+            ),
+            "positions": (
+                ("A", [0.0, 0.0, 0.0]),
+                ("B", [0.5, 0.0, 0.0]),
+            ),
+        },
+        "lattice": {
+            "size": [3, 2, 1],
+            "periodic": [True, True, True],
+        },
+        "hamiltonians": (
+            {"module": "applied-field", "field": [0.0, 0.0, 1.0]},
+        ),
+        "physics": {"module": "empty", "temperature": temperature},
+        "solver": solver,
+    }
+    return libconf.dumps(config)
+
+
+class TestConstrainedMonteCarlo(JamsIntegrationtest):
+    def run_config(self, config, *, setup_only=False, check=True):
+        args = [
+            self.binary_path,
+            "--name=jams",
+            "--config",
+            config,
+            f"--output={self.temp_dir}",
+        ]
+        if setup_only:
+            args.append("--setup-only")
+        return subprocess.run(
+            args,
+            check=check,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+    def test_zero_wavevector_initializes_plane_constraints(self):
+        config = constrained_mc_config(
+            temperature=0.0,
+            solver={
+                "module": "monte-carlo-constrained-cpu",
+                "max_steps": 1,
+                "cmc_constraint_mode": "spin_spiral",
+                "cmc_constraint_type": "magnetisation",
+                "cmc_constraint_theta": 5.0,
+                "cmc_constraint_phi": 0.0,
+                "cmc_spiral_wavevector": [0.0, 0.0, 0.0],
+                "cmc_spiral_axis": [0.0, 0.0, 1.0],
+                "cmc_spiral_propagation_direction": 0,
+            },
+        )
+
+        result = self.run_config(config, setup_only=True)
+        self.assertIn("zero-wavevector plane constraint yes", result.stdout)
+        self.assertIn("spiral propagation lattice direction 0", result.stdout)
+        self.assertIn("constrained planes 3", result.stdout)
+        self.assertEqual(result.stdout.count("4 magnetic spins"), 3)
+
+    def test_finite_temperature_adaptation_freezes_after_burn_in(self):
+        config = constrained_mc_config(
+            temperature=300.0,
+            solver={
+                "module": "monte-carlo-constrained-cpu",
+                "max_steps": 6,
+                "output_write_steps": 100,
+                "cmc_constraint_mode": "global",
+                "cmc_constraint_type": "magnetisation",
+                "cmc_constraint_theta": 5.0,
+                "cmc_constraint_phi": 0.0,
+                "move_angle_sigma": 0.01,
+                "move_angle_adaptation": {
+                    "enabled": True,
+                    "target_acceptance": 0.1,
+                    "interval_steps": 3,
+                    "gain": 0.5,
+                    "min_sigma": 1.0e-6,
+                    "max_sigma": 0.1,
+                    "burn_in_steps": 4,
+                },
+            },
+        )
+
+        result = self.run_config(config)
+        self.assertIn("move_angle_adaptation: step 3", result.stdout)
+        self.assertIn("move_angle_adaptation: step 4", result.stdout)
+        self.assertNotIn("move_angle_adaptation: step 5", result.stdout)
+        self.assertNotIn("move_angle_adaptation: step 6", result.stdout)
+        frozen = re.findall(r"frozen production sigma ([0-9.eE+-]+)", result.stdout)
+        self.assertEqual(len(frozen), 1)
+
+    def test_finite_temperature_adaptation_rejects_missing_burn_in(self):
+        config = constrained_mc_config(
+            temperature=300.0,
+            solver={
+                "module": "monte-carlo-constrained-cpu",
+                "max_steps": 6,
+                "cmc_constraint_mode": "global",
+                "cmc_constraint_type": "magnetisation",
+                "cmc_constraint_theta": 5.0,
+                "cmc_constraint_phi": 0.0,
+                "move_angle_sigma": 0.01,
+                "move_angle_adaptation": {
+                    "enabled": True,
+                    "target_acceptance": 0.1,
+                    "interval_steps": 3,
+                    "gain": 0.5,
+                    "min_sigma": 1.0e-6,
+                    "max_sigma": 0.1,
+                },
+            },
+        )
+        result = self.run_config(config, setup_only=True, check=False)
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn(
+            "move_angle_adaptation.burn_in_steps",
+            result.stdout + result.stderr,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Preserve spin-spiral plane grouping at zero wavevector using an explicit propagation direction, with validation and initialization logging.

Add opt-in log-space move-angle adaptation with angle-only acceptance statistics and finite-temperature burn-in freezing. Factor reusable configuration and vector validation helpers, and add focused unit tests, integration tests, documentation, and example configurations.

Tests: 59 ConstrainedMCSolver tests; Vec is_finite low-level test; git diff --check.